### PR TITLE
Fix typo in named parameter

### DIFF
--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -172,9 +172,9 @@ def get_possible_fields(in_pdf_file):
                   for i, bboxes_in_page in enumerate(bboxes_per_page)]
     return new_coords
 
-def intersect_bbox(bbox_a, bbox_b, dialation=2) -> bool:
-    a_left, a_right = bbox_a[0] - dialation, bbox_a[0] + bbox_a[2] + dialation
-    a_bottom, a_top = bbox_a[1] - dialation, bbox_a[1] + bbox_a[3] + dialation
+def intersect_bbox(bbox_a, bbox_b, dilation=2) -> bool:
+    a_left, a_right = bbox_a[0] - dilation, bbox_a[0] + bbox_a[2] + dilation
+    a_bottom, a_top = bbox_a[1] - dilation, bbox_a[1] + bbox_a[3] + dilation
     b_left, b_right = bbox_b[0], bbox_b[0] + bbox_b[2]
     b_bottom, b_top = bbox_b[1], bbox_b[1] + bbox_b[3]
     if a_bottom > b_top or a_top < b_bottom:


### PR DESCRIPTION
It doesn't look like we're referencing this named parameter anywhere--just want to be careful not to have typos in the function signature, as that can lead to future confusion.