### PR TITLE
Trigger a caught exception to download stopwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .ipynb_checkpoints
+formfyxer/__pycache__/**
+__pycache__/**
+*.egg-info/**

--- a/formfyxer/__init__.py
+++ b/formfyxer/__init__.py
@@ -1,2 +1,2 @@
 from .lit_explorer import *
-import pdf_wrangling
+from .pdf_wrangling import *

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -15,8 +15,10 @@ from sklearn.cluster import AffinityPropagation
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.preprocessing import normalize
 from joblib import load
+import nltk
 try:
     from nltk.corpus import stopwords
+    stopwords.words
 except:
     print("Downloading stopwords")
     nltk.download('stopwords')


### PR DESCRIPTION
nltk doesn't actually error out if you try to import data that hasn't been downloaded: you need to try to do something with that imported object. This PR adds a quick trigger of the exception, and worked on my machine when trying to just use formfyxer without installing data from nltk beforehand. 