### PR TITLE
Spacy on install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.0.0", "pip", "spacy"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,20 @@
 import setuptools
+from setuptools.command.install import install
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+class InstallSpacyModelCommand(install):
+    def run(self):
+        install.run(self)
+        import spacy
+        print("Downloading word2vec model en_core_web_lg")
+        spacy.cli.download('en_core_web_lg')
+
+
 setuptools.setup(
     name='formfyxer',
-    version='0.0.6',
+    version='0.0.7',
     author='Suffolk LIT Lab',
     author_email='litlab@suffolk.edu',
     description='A tool for learning about and pre-processing pdf forms.',
@@ -18,5 +27,9 @@ setuptools.setup(
     license='MIT',
     packages=['formfyxer'],
     install_requires=['spacy',  'PyPDF2',  'pikepdf',  'textstat',  'requests',  'numpy',  'sklearn', 'joblib',  'nltk', 'boxdetect', 'pdf2image', 'reportlab', 'pdfminer.six', 'opencv-python'],
+    cmdclass={
+      'install': InstallSpacyModelCommand,
+    },
     include_package_data = True
 )
+


### PR DESCRIPTION
Installs necessary `spacy` models on an install instead of waiting for runtime. Tested on the command in a new virtual environment, on a locally running docker container of docassemble, and a brand new docassemble on Lightsail using S3. I can confirm that the docassemble on Lightsail only takes 7 seconds to start the first ALWeaver interview (much shorter than if it was trying to download the entire spacy model at start time).

Honestly, the only good documentation on how to do this was from [blogs talking about malicious code](https://github.com/Ayrx/malicious-python-package/blob/master/setup.py), which makes me feel a bit icky, but I guess it is what the feature is built for. Added a `pyproject.toml` ([documentation here](https://packaging.python.org/en/latest/tutorials/packaging-projects/#creating-pyproject-toml)) to let setup tools know what packages are needed to run `setup.py`, which both our github publish action and pip when installing our package on docassemble are using.

The only remaining source of confusion is why we needed to include `"pip"` in the built tool requires. Docassemble fails without it  ("No module named pip"), but seems to work fine with it. I think it could be a pip bug (that might be more recently fixed? [this issue](https://github.com/pypa/pip/issues/10573) seems similar, but not exactly the same, and was only fixed recently). 