### PR TITLE
Improve field finding in PDFs:

### DIFF
--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -26,6 +26,9 @@ from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfparser import PDFParser
 
+# Change this to true to output lots of images to help understand why a kernel didn't work
+DEBUG = False
+
 ######## PDF internals related funcitons ##########
 
 class FieldType(Enum):
@@ -359,9 +362,13 @@ def get_possible_fields(in_pdf_file: Union[str, Path, bytes]) -> List[List[FormF
     text_in_pdf = get_textboxes_in_pdf(in_pdf_file)
     if not any([y is not None and len(y) for y in checkbox_bboxes_per_page]):
         all_text =  ' '.join([' '.join([page_item[0].get_text() for page_item in page]) for page in text_in_pdf])
-        if '[ ]' in all_text:
+        if re.search(r'\[ {1,3}\]', all_text):
+            if DEBUG:
+                print('finding in text')
             checkbox_pdf_bboxes = get_bracket_chars_in_pdf(in_pdf_file)
         else:
+            if DEBUG:
+                print('finding small')
             checkbox_bboxes_per_page = [get_possible_checkboxes(tmp.name, find_small=True) for tmp in tmp_files]
             checkbox_pdf_bboxes = [[img2pdf_coords(bbox, images[i].height) for bbox, _, _ in bboxes_in_page]
                                    for i, bboxes_in_page in enumerate(checkbox_bboxes_per_page)]

--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -6,7 +6,6 @@ import tempfile
 from typing import Any, Dict, Iterable, Optional, List, Union, Tuple, BinaryIO, Mapping
 from numbers import Number
 from pathlib import Path
-from io import StringIO
 
 import cv2
 from boxdetect import config
@@ -29,6 +28,7 @@ from pdfminer.pdfparser import PDFParser
 
 class FieldType(Enum):
     TEXT = 'text'  # Text input Field
+    AREA = 'area'  # Text input Field, but an area
     CHECK_BOX = 'checkbox'
     LIST_BOX = 'listbox'  # allows multiple selection
     CHOICE = 'choice'  # allows only one selection
@@ -39,7 +39,7 @@ class FormField:
     """A data holding class, used to easily specify how a PDF form field should be created."""
 
     def __init__(self, program_name: str, type_name: Union[FieldType, str], x: int, y: int,
-                 user_name: str = '', configs: Dict[str, Any] = None):
+                 font_size:int = 20, user_name: str = '', configs: Dict[str, Any] = None):
         """
         Constructor
 
@@ -64,7 +64,8 @@ class FormField:
         self.x = x
         self.y = y
         self.user_name = user_name
-        # TODO(brycew): If we aren't given options, make our own depending on self.type
+        self.font_size = font_size
+        # If we aren't given options, make our own depending on self.type
         if self.type == FieldType.CHECK_BOX:
             self.configs = {
                 'buttonStyle': 'check',
@@ -76,6 +77,10 @@ class FormField:
         elif self.type == FieldType.TEXT:
             self.configs = {
                 'fieldFlags': 'doNotScroll'
+            }
+        elif self.type == FieldType.AREA:
+            self.configs = {
+                'fieldFlags': 'doNotScroll multiline',
             }
         else:
             self.configs = {}
@@ -99,7 +104,12 @@ def _create_only_fields(io_obj, fields_per_page: Iterable[Iterable[FormField]], 
     form = c.acroForm
     for fields in fields_per_page:
         for field in fields:
+            if hasattr(field, 'font_size'):
+                c.setFont(font_name, field.font_size)
             if field.type == FieldType.TEXT:
+                form.textfield(name=field.name, tooltip=field.user_name,
+                               x=field.x, y=field.y, **field.configs)
+            elif field.type == FieldType.AREA:
                 form.textfield(name=field.name, tooltip=field.user_name,
                                x=field.x, y=field.y, **field.configs)
             elif field.type == FieldType.CHECK_BOX:
@@ -168,6 +178,12 @@ def rename_pdf_fields(in_file: str, out_file: str, mapping: Mapping[str, str]) -
 
     in_pdf.save(out_file)
 
+def get_existing_pdf_fields(in_file: Union[str, Path, BinaryIO, Pdf]) -> Iterable:
+    if isinstance(in_file, Pdf):
+      in_pdf = in_file
+    else:
+      in_pdf = Pdf.open(in_file)
+    return [{'type': field.FT, 'var_name': field.T, 'all': field} for field in in_pdf.Root.AcroForm.Fields]
 
 def swap_pdf_page(*, 
                     source_pdf: Union[str, Path, Pdf],
@@ -195,7 +211,7 @@ def swap_pdf_page(*,
             continue  # no fields on this page, skip
         annots = source_pdf.make_indirect(source_page.Annots)
         if append_fields and hasattr(destination_page, 'Annots'):
-            destination_page.Annots.extend(destination_pdf.copy_foreign(annots))            
+            destination_page.Annots.extend(destination_pdf.copy_foreign(annots))
         else:
             destination_page['/Annots'] = destination_pdf.copy_foreign(annots)
     return destination_pdf
@@ -211,7 +227,7 @@ class MyPDFPageAggregator(PDFLayoutAnalyzer):
     def get_result(self) -> LTPage:
         return self.results
 
-def get_textboxes_in_pdf(in_file:str) -> List:
+def get_textboxes_in_pdf(in_file:str, get_type=LTTextBoxHorizontal, line_margin=0.02) -> List:
     """Gets all of the text boxes found by pdfminer in a PDF, as well as their bounding boxes"""
     if isinstance(in_file, str):
         open_file = open(in_file, 'rb')
@@ -220,7 +236,7 @@ def get_textboxes_in_pdf(in_file:str) -> List:
     parser = PDFParser(open_file)
     doc = PDFDocument(parser)
     rsrcmgr = PDFResourceManager()
-    device = MyPDFPageAggregator(rsrcmgr, laparams=LAParams(line_margin=0.02)) 
+    device = MyPDFPageAggregator(rsrcmgr, laparams=LAParams(line_margin=line_margin))
     interpreter = PDFPageInterpreter(rsrcmgr, device)
     page_count = 0
     for page in PDFPage.create_pages(doc):
@@ -228,13 +244,27 @@ def get_textboxes_in_pdf(in_file:str) -> List:
         interpreter.process_page(page)
     if isinstance(in_file, str):
         open_file.close() 
-    return [[(obj, (obj.x0, obj.y0, obj.width, obj.height)) for obj in device.get_result()[i]._objs if isinstance(obj, LTTextBoxHorizontal) and obj.get_text().strip(' \n') != '']
+    return [[(obj, (obj.x0, obj.y0, obj.width, obj.height)) for obj in device.get_result()[i]._objs if isinstance(obj, get_type) and obj.get_text().strip(' \n') != '']
             for i in range(page_count)]
 
 ####### OpenCV related functions #########
 
 BoundingBox = Tuple[Number, Number, Number, Number]
 XYPair = Tuple[Number, Number]
+
+pts_in_inch = 72
+dpi = 200
+def unit_convert(pix): return pix / dpi * pts_in_inch
+
+def img2pdf_coords(img, max_height):
+    # If bbox: X, Y, width, height, and whatever else you want (we won't return it)
+    if len(img) >= 4:
+        return (unit_convert(img[0]), unit_convert(max_height - img[1]), unit_convert(img[2]), unit_convert(img[3]))
+    # If just X and Y
+    elif len(img) >= 2:
+        return (unit_convert(img[0]), unit_convert(max_height - img[1]))
+    else:
+        return (unit_convert(img[0]))
 
 def get_possible_fields(in_pdf_file: Union[str, Path, bytes]) -> List[List[FormField]]:
     dpi = 200
@@ -244,75 +274,76 @@ def get_possible_fields(in_pdf_file: Union[str, Path, bytes]) -> List[List[FormF
     for file_obj, img in zip(tmp_files, images):
         img.save(file_obj, 'JPEG')
         file_obj.flush()
-    text_bboxes_per_page = [get_possible_text_fields(
-        tmp_file.name) for tmp_file in tmp_files]
-    checkbox_bboxes_per_page = [get_possible_checkboxes(
-        tmp_file.name) for tmp_file in tmp_files]
 
-    pts_in_inch = 72
-    def unit_convert(pix): return pix / dpi * pts_in_inch
+    text_in_pdf = get_textboxes_in_pdf(in_pdf_file)
+    text_bboxes_per_page = [get_possible_text_fields(tmp.name, page_text)
+            for tmp, page_text in zip(tmp_files, text_in_pdf)]
+    checkbox_bboxes_per_page = [get_possible_checkboxes(tmp.name) for tmp in tmp_files]
+    any_checkboxes_in_pdf = any([y is not None and len(y) for y in checkbox_bboxes_per_page])
+    if not any_checkboxes_in_pdf:
+      for idx in len(checkbox_bboxes_per_page):
+        checkbox_bboxes_per_page[idx] = get_possible_brackets(tmp_files[idx].name)
 
-    def img2pdf_coords(img, max_height):
-        # If bbox: X, Y, width, height, and whatever else you want (we won't return it)
-        if len(img) >= 4:
-            return (unit_convert(img[0]), unit_convert(max_height - img[1]), unit_convert(img[2]), unit_convert(img[3]))
-        # If just X and Y
-        elif len(img) >= 2:
-            return (unit_convert(img[0]), unit_convert(max_height - img[1]))
-        else:
-            return (unit_convert(img[0]))
-
-    text_pdf_bboxes = [[img2pdf_coords(bbox, images[i].height) for bbox in bboxes_in_page]
+    text_pdf_bboxes = [[(img2pdf_coords(bbox, images[i].height), font_size) for bbox, font_size in bboxes_in_page]
                        for i, bboxes_in_page in enumerate(text_bboxes_per_page)]
     checkbox_pdf_bboxes = [[img2pdf_coords(bbox, images[i].height) for bbox, _, _ in bboxes_in_page]
                            for i, bboxes_in_page in enumerate(checkbox_bboxes_per_page)]
-    text_in_pdf = get_textboxes_in_pdf(in_pdf_file)
 
     fields = []
     i = 0
     for bboxes_in_page, checkboxes_in_page, text_in_page in zip(text_pdf_bboxes, checkbox_pdf_bboxes, text_in_pdf):
         text_obj_bboxes = [text[1] for text in text_in_page]
         page_fields = []
-        for j, field_bbox in enumerate(bboxes_in_page):
-          intersected = [obj for obj, intersect in zip(text_in_page, intersect_bboxs(field_bbox, text_obj_bboxes, dilation=50)) if intersect]
+        for j, field_info in enumerate(bboxes_in_page):
+          field_bbox, font_size = field_info
+          intersected = [obj for obj, intersect in zip(text_in_page, intersect_bboxs(field_bbox, text_obj_bboxes, horiz_dilation=50, vert_dilation=50)) if intersect]
           if intersected:
               dists = [(bbox_distance(field_bbox, bbox)[0], obj) for obj, bbox, in intersected]
-              print(f'Choices: {[(dist, obj.get_text()) for dist, obj in dists]}')
               min_obj = min(dists, key=lambda d: d[0])
               # TODO(brycew): actual regex replacement of lots of underscores
               label = re.sub('[\W]', '_', min_obj[1].get_text().lower().strip(' \n\t_,')) 
               label = re.sub('_{3,}', '_', label)
           else:
               label = f'page_{i}_field_{j}'
-          page_fields.append(FormField(label, FieldType.TEXT, field_bbox[0], field_bbox[1], configs={'width': field_bbox[2], 'height': 16}))
+          # By default the line size is 16.
+          if field_bbox[3] > 24:
+              page_fields.append(FormField(label, FieldType.AREA, field_bbox[0], field_bbox[1], font_size=font_size, configs={'width': field_bbox[2], 'height': field_bbox[3]}))
+          else:
+              page_fields.append(FormField(label, FieldType.TEXT, field_bbox[0], field_bbox[1], font_size=font_size, configs={'width': field_bbox[2], 'height': field_bbox[3]}))
 
-        page_fields += [FormField(f'page_{i}_check_{j}', FieldType.CHECK_BOX, bbox[0] + bbox[2]/4, bbox[1] - bbox[3], configs={'size': min(bbox[2], bbox[3])})
+        page_fields += [FormField(f'page_{i}_check_{j}', FieldType.CHECK_BOX, bbox[0], bbox[1] - bbox[3], configs={'size': min(bbox[2], bbox[3])})
                         for j, bbox in enumerate(checkboxes_in_page)]
         i += 1
         fields.append(page_fields)
 
     return fields
 
-def intersect_bbox(bbox_a, bbox_b, dilation=2) -> bool:
-    a_bottom, a_top = bbox_a[1] - dilation, bbox_a[1] + bbox_a[3] + dilation
+def intersect_bbox(bbox_a, bbox_b, vert_dilation=2, horiz_dilation=2) -> bool:
+    """bboxes are [left edge, bottom edge, horizontal length, vertical length]"""
+    a_bottom, a_top = bbox_a[1] - vert_dilation, bbox_a[1] + bbox_a[3] + vert_dilation
     b_bottom, b_top = bbox_b[1], bbox_b[1] + bbox_b[3]
     if a_bottom > b_top or a_top < b_bottom:
         return False
 
-    a_left, a_right = bbox_a[0] - dilation, bbox_a[0] + bbox_a[2] + dilation
+    a_left, a_right = bbox_a[0] - horiz_dilation, bbox_a[0] + bbox_a[2] + horiz_dilation
     b_left, b_right = bbox_b[0], bbox_b[0] + bbox_b[2]
     if a_left > b_right or a_right < b_left:
         return False
     return True
 
-
-def intersect_bboxs(bbox_a, bboxes, dilation=2) -> Iterable[bool]:
+def intersect_bboxs(bbox_a, bboxes, vert_dilation=2, horiz_dilation=2) -> Iterable[bool]:
     """Returns an iterable of booleans, one of each of the input bboxes, true if it collides with bbox_a"""
-    a_left, a_right = bbox_a[0] - dilation, bbox_a[0] + bbox_a[2] + dilation
-    a_bottom, a_top = bbox_a[1] - dilation, bbox_a[1] + bbox_a[3] + dilation
+    a_left, a_right = bbox_a[0] - horiz_dilation, bbox_a[0] + bbox_a[2] + horiz_dilation
+    a_bottom, a_top = bbox_a[1] - vert_dilation, bbox_a[1] + bbox_a[3] + vert_dilation
     return [a_top > bbox[1] and a_bottom < (bbox[1] + bbox[3]) and a_right > bbox[0] and a_left < (bbox[0] + bbox[2])
             for bbox in bboxes]
 
+def contain_boxes(bbox_a, bbox_b):
+    """Given two bounding boxes, return a single bounding box that contains both of them."""
+    top, bottom = min(bbox_a[1] - bbox_a[3], bbox_b[1] - bbox_b[3]), max(bbox_a[1], bbox_b[1])
+    left, right = min(bbox_a[0], bbox_b[0]), max(bbox_a[0] + bbox_a[2], bbox_b[0] + bbox_b[2])
+    to_ret = [left, bottom, right - left, bottom - top]
+    return to_ret
 
 def get_dist_sq(point_a, point_b):
     """returns the distance squared between two points. Faster than the true euclidean dist"""
@@ -373,39 +404,78 @@ def bbox_distance(bbox_a, bbox_b) -> Tuple[float, Tuple[XYPair, XYPair], Tuple[X
 
 
 def get_possible_checkboxes(img: Union[str, cv2.Mat]) -> np.ndarray:
-    """Uses boxdetect library to determine if there are checkboxes on an image of a PDF page"""
+    """Uses boxdetect library to determine if there are checkboxes on an image of a PDF page.
+    Assumes the checkbox is square.
+    """
     cfg = config.PipelinesConfig()
     # Defaults from the README. TODO(brycew): adjust per state?
-    cfg.width_range = (32, 65)
-    cfg.height_range = (25, 40)
+    cfg.width_range = (20, 65)
+    cfg.height_range = (20, 40)
     cfg.scaling_factors = [0.6]
     cfg.wh_ratio_range = (0.6, 2.2)
     cfg.group_size_range = (2, 100)
     cfg.dilation_iterations = 0
+    cfg.morph_kernels_type = 'rectangles'
     checkboxes = get_checkboxes(
         img, cfg=cfg, px_threshold=0.1, plot=False, verbose=False)
-    print(checkboxes)
+    return checkboxes
+
+def get_possible_brackets(img: Union[str, cv2.Mat]) -> np.ndarray:
+    """Uses a modified version of boxdetect to determine if there are brackets ([ ]) on an
+    image of a PDF page. Assumes a lot about the size (right now calibrated to Washington's
+    forms), and will often come up with false positives in general text."""
+    cfg = config.PipelinesConfig()
+    # Defaults from the README. TODO(brycew): adjust per state?
+    cfg.width_range = (14, 20)
+    cfg.height_range = (24, 30)
+    cfg.scaling_factors = [1.0]
+    cfg.wh_ratio_range = (0.5, 0.8)
+    cfg.group_size_range = (2, 100)
+    cfg.dilation_iterations = 0
+    cfg.morph_kernels_type = 'brackets'
+    checkboxes = get_checkboxes(
+        img, cfg=cfg, px_threshold=0.1, plot=False, verbose=False)
     return checkboxes
 
 
 def get_possible_radios(img: Union[str, BinaryIO, cv2.Mat]):
-    """NOT implemented placeholder for now.
-    Need to figure out how to the semantic difference between checkboxes and radio buttons"""
+    """Even though it's called "radios", it just gets things shaped like circles, not
+    doing any semantic analysis yet."""
     if isinstance(img, str):
         # 0 is for the flags: means nothing special is being used
         img = cv2.imread(img, 0)
     if isinstance(img, BinaryIO):
         img = cv2.imdecode(np.frombuffer(img.read(), np.uint8), 0)
-
+    
+    rows = img.shape[0]
+    # TODO(brycew): https://docs.opencv.org/3.4/d4/d70/tutorial_hough_circle.html
+    circles = cv2.HoughCircles(img, cv2.HOUGH_GRADIENT, 1, rows/8,
+            param1=100, param2=30, minRadius=5, maxRadius=50)
+    if circles is not None:
+        circles = np.uint16(np.around(circles))
+        for i in circles[0, :]:
+            center = (i[0], i[1])
+            # circle center
+            cv2.circle(img, center, 1, (0, 100, 100), 3)
+            # circle outline
+            radius = i[2]
+            cv2.circle(img, center, radius, (255, 0, 255), 3)
+    
+    return []
+    #cv2.imshow("detected circles", img)
+    #cv2.waitKey(0)
+    
     # TODO(brycew): need to support radio buttons further down the Weaver pipeline as well
     pass
 
 
-def get_possible_text_fields(img: Union[str, BinaryIO, cv2.Mat]) -> List[List[BoundingBox]]:
+def get_possible_text_fields(img: Union[str, BinaryIO, cv2.Mat], text_lines, default_line_height:int=44) -> List[List[BoundingBox]]:
     """Uses openCV to attempt to find places where a PDF could expect an input text field.
 
     Caveats so far: only considers straight, normal horizonal lines that don't touch any vertical lines as fields
     Won't find field inputs as boxes
+
+    default_line_height: the default height (16 pt), in pixels (at 200 dpi), which is 45
     """
     if isinstance(img, str):
         # 0 is for the flags: means nothing special is being used
@@ -413,6 +483,7 @@ def get_possible_text_fields(img: Union[str, BinaryIO, cv2.Mat]) -> List[List[Bo
     if isinstance(img, BinaryIO):
         img = cv2.imdecode(np.frombuffer(img.read(), np.uint8), 0)
 
+    height, width = img.shape
     # fixed level thresholding, turning a gray scale / multichannel img to a black and white one.
     # OTSU = optimum global thresholding: minimizes the variance of each Thresh "class"
     # for each possible thresh value between 128 and 255, split up pixels, get the within-class variance,
@@ -434,7 +505,7 @@ def get_possible_text_fields(img: Union[str, BinaryIO, cv2.Mat]) -> List[List[Bo
         cv2.MORPH_RECT, (kernel_length, 1))
     horizontal_lines_img = cv2.dilate(
         cv2.erode(img_bin, horiz_kernel, iterations=3), horiz_kernel, iterations=3)
-    cv2.imwrite("Img_hori.png", vertical_lines_img)
+    cv2.imwrite("Img_hori.png", horizontal_lines_img)
 
     alpha = 0.5
     img_final_bin = cv2.addWeighted(
@@ -454,6 +525,8 @@ def get_possible_text_fields(img: Union[str, BinaryIO, cv2.Mat]) -> List[List[Bo
             coord = 1
         # construct list of bounding boxes and sort them top to bottom
         boundingBoxes = [cv2.boundingRect(c) for c in cnts]
+        if not boundingBoxes:
+          return [[], []]
         (cnts, boundingBoxes) = zip(*sorted(zip(cnts, boundingBoxes),
                                             key=lambda b: b[1][coord], reverse=reverse))
         # return the list of sorted contours and bounding boxes
@@ -461,20 +534,55 @@ def get_possible_text_fields(img: Union[str, BinaryIO, cv2.Mat]) -> List[List[Bo
     (contours, boundingBoxes) = sort_contours(contours, method='top-to-bottom')
     vert_contours, _ = cv2.findContours(
         vertical_lines_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
-    # TODO(brycew): also consider checking that the PDF is really blank ~ 1 line space above the horiz line
     if vert_contours:
         # Don't consider horizontal lines that meet up against vertical lines as text fields
         (vert_contours, vert_bounding_boxes) = sort_contours(
             vert_contours, method='top-to-bottom')
-        to_return = []
+        no_vert_coll = []
         for bbox in boundingBoxes:
-            inters = [intersect_bbox(vbbox, bbox)
+            inters = [intersect_bbox(vbbox, bbox, vert_dilation=5)
                       for vbbox in vert_bounding_boxes]
             if not any(inters):
-                to_return.append(bbox)
-        return to_return
+                no_vert_coll.append(bbox)
     else:
-        return boundingBoxes
+        no_vert_coll = boundingBoxes
+
+    text_obj_bboxes = [text[1] for text in text_lines]
+
+    to_return = []
+    for idx, bbox in enumerate(no_vert_coll):
+        intersected = [obj for obj, intersect in zip(text_lines, intersect_bboxs(img2pdf_coords(bbox, max_height=height), text_obj_bboxes, horiz_dilation=50)) if intersect]
+        if intersected:
+            dists = [(bbox_distance(bbox, text_bbox)[0], obj) for obj, text_bbox, in intersected]
+            min_obj = min(dists, key=lambda d: d[0])
+            line_height = int(min_obj[1].height * 200 / 72)
+        else:
+            line_height = int(default_line_height)
+
+        # also consider checking that the PDF is really blank, ~ 1 line space above the horiz line
+        bbox = (bbox[0], bbox[1], bbox[2], line_height) # change bbox height (likely 0 or 1) to the right height
+        # TODO(brycew): hardcoded space above
+        margin = 8
+        left_margin = bbox[2] // 5
+        sub_img = img_bin[bbox[1] - bbox[3] + margin:bbox[1] - 5, bbox[0] + left_margin:bbox[0]+bbox[2]- margin]
+        if sub_img.any():
+            continue
+        
+        if to_return:
+            last_bbox = to_return[-1][0]
+            # if they are at least 60 px above / below each other
+            if intersect_bbox(bbox, last_bbox, vert_dilation=30):
+                left, right = max(bbox[0], last_bbox[0]), min(bbox[0] + bbox[2], last_bbox[0] + last_bbox[2])
+                overlap_dist = right - left
+                # if the overlap of each is greater than 90% dist of both
+                if overlap_dist > 0.98 * bbox[2] and overlap_dist > 0.98 * last_bbox[2]:
+                    sub_img = img_bin[last_bbox[1] + margin:bbox[1] - 5, bbox[0] + margin:bbox[0]+bbox[2]- margin]
+                    left_img = img_bin[bbox[1] - bbox[3] + margin:bbox[1] - margin, bbox[0] - 40:bbox[0] - margin]
+                    if not left_img.any() and not sub_img.any():
+                      to_return.pop()
+                      bbox = contain_boxes(bbox, last_bbox)
+        to_return.append((bbox, line_height))
+    return to_return
 
 
 def auto_add_fields(in_pdf_file: Union[str, Path], out_pdf_file: Union[str, Path]):
@@ -482,3 +590,4 @@ def auto_add_fields(in_pdf_file: Union[str, Path], out_pdf_file: Union[str, Path
     to an input PDF."""
     fields = get_possible_fields(in_pdf_file)
     set_fields(in_pdf_file, out_pdf_file, fields, overwrite=True)
+

--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -374,7 +374,6 @@ def img2pdf_coords(img, max_height):
         return (unit_convert(img[0]))
 
 def get_possible_fields(in_pdf_file: Union[str, Path, bytes]) -> List[List[FormField]]:
-    dpi = 200
     images = convert_from_path(in_pdf_file, dpi=dpi)
 
     tmp_files = [tempfile.NamedTemporaryFile() for i in range(len(images))]
@@ -394,10 +393,10 @@ def get_possible_fields(in_pdf_file: Union[str, Path, bytes]) -> List[List[FormF
             if DEBUG:
                 print('finding small')
             checkbox_bboxes_per_page = [get_possible_checkboxes(tmp.name, find_small=True) for tmp in tmp_files]
-            checkbox_pdf_bboxes = [[img2pdf_coords(bbox, images[i].height) for bbox, _, _ in bboxes_in_page]
+            checkbox_pdf_bboxes = [[img2pdf_coords(bbox, images[i].height) for bbox in bboxes_in_page]
                                    for i, bboxes_in_page in enumerate(checkbox_bboxes_per_page)]
     else: 
-        checkbox_pdf_bboxes = [[img2pdf_coords(bbox, images[i].height) for bbox, _, _ in bboxes_in_page]
+        checkbox_pdf_bboxes = [[img2pdf_coords(bbox, images[i].height) for bbox in bboxes_in_page]
                                for i, bboxes_in_page in enumerate(checkbox_bboxes_per_page)]
 
     text_bboxes_per_page = [get_possible_text_fields(tmp.name, page_text)
@@ -540,7 +539,7 @@ def get_possible_checkboxes(img: Union[str, cv2.Mat], find_small=False) -> np.nd
     cfg.morph_kernels_type = 'rectangles'
     checkboxes = get_checkboxes(
         img, cfg=cfg, px_threshold=0.1, plot=False, verbose=False)
-    return checkboxes
+    return [checkbox for checkbox, contains_pix, _ in checkboxes if not contains_pix]
 
 
 def get_possible_radios(img: Union[str, BinaryIO, cv2.Mat]):

--- a/scripts/auto_fields_all.py
+++ b/scripts/auto_fields_all.py
@@ -14,17 +14,16 @@ def main():
     return
   in_folder = sys.argv[1]
   out_folder = sys.argv[2]
-  to_process = [in_file for in_file in os.listdir(in_folder) if in_file.lower().endswith('.pdf')]
-  print(to_process)
+  to_process = sorted([in_file for in_file in os.listdir(in_folder) if in_file.lower().endswith('.pdf')])
   for in_file in to_process:
     try:
       p = Pdf.open(in_folder + '/' + in_file)
+      print(f'Starting on {in_file}')
       p.Root.AcroForm = []
       for page in p.pages:
         page.Annots = []
       tmp_file = tempfile.NamedTemporaryFile()
       p.save(tmp_file.name)
-      print(tmp_file.name)
       tmp_file.flush()
       auto_add_fields(tmp_file.name, out_folder + '/' + in_file)
     except Exception as ex:

--- a/scripts/auto_fields_all.py
+++ b/scripts/auto_fields_all.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import tempfile
+from pikepdf import Pdf
+
+from formfyxer.pdf_wrangling import auto_add_fields
+
+def main():
+  """Pass in an in-folder with PDFs, we'll strip off the fields and run our stuff over them"""
+  if len(sys.argv) < 3:
+    print('Need to pass in an in folder and a out folder!')
+    return
+  in_folder = sys.argv[1]
+  out_folder = sys.argv[2]
+  to_process = [in_file for in_file in os.listdir(in_folder) if in_file.lower().endswith('.pdf')]
+  print(to_process)
+  for in_file in to_process:
+    try:
+      p = Pdf.open(in_folder + '/' + in_file)
+      p.Root.AcroForm = []
+      for page in p.pages:
+        page.Annots = []
+      tmp_file = tempfile.NamedTemporaryFile()
+      p.save(tmp_file.name)
+      print(tmp_file.name)
+      tmp_file.flush()
+      auto_add_fields(tmp_file.name, out_folder + '/' + in_file)
+    except Exception as ex:
+      print(f"Got exception for {in_file}: {ex}")
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
* Collapses multiple text lines with nothing in the middle (and nothing to the left, since often multiple fields can have their labels off to the left) into a text area
* detect the size of a text field, and roughly use it to set the font size so
  the text field is readable on PDFs with smaller font sizes
* add a checkbox detector that works for brackets "[ ]" by searching in PDF text for instances of `[ ]` or `[  ]`
* don't add duplicate field labels!
* fixed some issues with label bounding boxes being really big because it includes the field itself, which was causing some text to be labels for multiple fields, even it it wasn't that good of a choice
* skip over checkboxes that look like they're filled in (when using `boxdetect`), as they're likely false positives (we're only looking for empty checkboxes)
* don't add text boxes if:
  * there are things above the line that aren't blank
* Adds a script to run strip fields and run auto fields over all PDFs in a folder easily

## Compare

Admittedly cherry-picked, but it's because we were pretty good before and not much changed in many forms except for font size.
We were finding checkboxes, but I tweaked some params there to find more, because many were too small.

  
### Before

![Screenshot from 2022-08-19 17-45-34](https://user-images.githubusercontent.com/6252212/185711422-ca50ebdb-db01-4bbd-af96-4fe7edca7e58.png)

  
### After 

![Screenshot from 2022-08-19 17-41-41](https://user-images.githubusercontent.com/6252212/185711090-7e16c3c9-86da-4550-ab4b-a2fd5c1613a1.png)

