### PR TITLE
Use PikePDF and pdfminer.six

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/**
 *.egg-info/**
 build/**
 dist/**
+.history/

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -1,5 +1,3 @@
-# Updated on 2022-03-21
-
 import os
 import re
 import spacy
@@ -28,7 +26,8 @@ import math
 from contextlib import contextmanager
 import threading
 import _thread
-from typing import Union, Path, BinaryIO, Iterable
+from typing import Union, BinaryIO, Iterable
+from pathlib import Path
 
 stop_words = set(stopwords.words('english'))
 
@@ -159,7 +158,7 @@ def regex_norm_field(text):
         ["^Zip( Code)?$","users1_address_zip"],
         ## Contact
         ["^(Phone|Telephone)$","users1_phone_number"],
-        ["^Email( Adress)$","users1_email"],
+        ["^Email( Address)$","users1_email"],
 
         # Parties
         ["^plaintiff\(?s?\)?$","plaintiff1_name"],
@@ -180,7 +179,7 @@ def regex_norm_field(text):
         text = re.sub(regex[0],regex[1],text, flags=re.IGNORECASE)
     return text
 
-# Tranforms a string of text into a snake_case variable close in length to `max_length` name by summarizing the string and stiching the summary together in snake_case. h/t h/t https://towardsdatascience.com/nlp-building-a-summariser-68e0c19e3a93
+# Transforms a string of text into a snake_case variable close in length to `max_length` name by summarizing the string and stitching the summary together in snake_case. h/t h/t https://towardsdatascience.com/nlp-building-a-summariser-68e0c19e3a93
 
 def reformat_field(text, max_length=30):
     orig_title = text.lower()
@@ -331,7 +330,7 @@ def cluster_screens(fields=[],damping=0.7):
 
     # create model
     model = AffinityPropagation(damping=damping)
-    #model = AffinityPropagation(damping=damping,random_state=4) consider using this to get consitent results. note will have to requier newer version
+    #model = AffinityPropagation(damping=damping,random_state=4) consider using this to get consistent results. note will have to require newer version
     # fit the model
     model.fit(vec_mat)
     # assign a cluster to each example
@@ -356,7 +355,7 @@ def get_existing_pdf_fields(in_file: Union[str, Path, BinaryIO, pikepdf.Pdf]) ->
       in_pdf = in_file
     else:
       in_pdf = pikepdf.Pdf.open(in_file)
-    return [{'type': field.FT, 'var_name': field.T, 'all': field} for field in in_pdf.Root.AcroForm.Fields]
+    return [{'type': field.FT, 'var_name': str(field.T), 'all': field} for field in in_pdf.Root.AcroForm.Fields]
 
 
 def unlock_pdf_in_place(in_file:str):
@@ -409,6 +408,7 @@ def parse_form(in_file:str, title:str=None, jur:str=None, cat:str=None, normaliz
     else:
         fields = []
     f_per_page = len(fields)/npages
+    text = cleanup_text(extract_text(in_file))
 
     if title is None:
         matches = re.search("(.*)\n",text)
@@ -417,7 +417,7 @@ def parse_form(in_file:str, title:str=None, jur:str=None, cat:str=None, normaliz
         else:
             title = "(Untitled)"
 
-    text = cleanup_text(extract_text(in_file))
+    
     try:
         if text != "":
             readability = textstat.text_standard(text, float_output=True)
@@ -483,7 +483,7 @@ def parse_form(in_file:str, title:str=None, jur:str=None, cat:str=None, normaliz
 
 def form_complexity(text,fields,reading_lv):
     
-    # check for fields that requier user to look up info, when found add to complexity
+    # check for fields that require user to look up info, when found add to complexity
     # maybe score these by minutes to recall/fill out
     # so, figure out words per minute, mix in with readability and page number and field numbers
     

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     },
     license='MIT',
     packages=['formfyxer'],
-    install_requires=['spacy',  'PyPDF2',  'pikepdf',  'textstat',  'requests',  'numpy',  'sklearn', 'networkx',
+    install_requires=['spacy', 'pdfminer.six', 'pikepdf',  'textstat',  'requests',  'numpy',  'sklearn', 'networkx',
         'joblib',  'nltk', 'boxdetect', 'pdf2image', 'reportlab', 'pdfminer.six', 'opencv-python',
         'typer>=0.4.1,<0.5.0' # typer pre 0.4.1 was broken by click 8.1.0: https://github.com/explosion/spaCy/issues/10564
     ],


### PR DESCRIPTION
Switching to pdfminer.six should resolve some of the artifacts that we've run into with readability stats. There is a known issue with pypdf2 which sometimes results in extracting the wrong text from a PDF. Switching to pdfminer.six should resolve some of the artifacts that we've run into with readability stats.

I created a new `cleanup_text()` function which makes slightly different assumptions about how to segment a PDF for purposes of calculating readability. E.g.,

- There should be no "empty" sentences with just spaces and periods
- We remove special characters other than normal punctuation, including lines added in Word as `________` or `------`
- A fixed `reCase` function to separate PamelCase, camelCase, kebab-case and snake_case words
- We replace every `:` with a `.` My assumption is that the user reads each label for a field in isolation, which means that one sentence per field is correct. This may drastically bump down the grade level for a lot of forms, as sentence length has a heavy weight in many readability formulas.

I've also caught a few small typos and made a few minor changes to the function signature, such as replacing numbers treated as boolean flags with actual boolean values. NOTE: shouldn't be a breaking change but we should change the places it's referenced to use booleans anyway.

Did a little cleanup - added docstrings. Will save running this through `black` for a standalone PR.

Fix #63
Fix #28
Fix #7