### PR TITLE
Refactor for relabeling fields

### DIFF
--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -288,6 +288,26 @@ def swap_pdf_page(
     destination_offset: int = 0,
     append_fields: bool = False,
 ) -> Pdf:
+    """(DEPRECATED: use copy_pdf_fields) Copies the AcroForm fields from one PDF to another blank PDF form. Optionally, choose a starting page for both
+    the source and destination PDFs. By default, it will remove any existing annotations (which include form fields)
+    in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`"""
+    return copy_pdf_fields(
+        source_pdf=source_pdf,
+        destination_pdf=destination_pdf,
+        source_offset=source_offset,
+        destination_offset=destination_offset,
+        append_fields=append_fields,
+    )
+
+
+def copy_pdf_fields(
+    *,
+    source_pdf: Union[str, Path, Pdf],
+    destination_pdf: Union[str, Path, Pdf],
+    source_offset: int = 0,
+    destination_offset: int = 0,
+    append_fields: bool = False,
+) -> Pdf:
     """Copies the AcroForm fields from one PDF to another blank PDF form. Optionally, choose a starting page for both
     the source and destination PDFs. By default, it will remove any existing annotations (which include form fields)
     in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`"""

--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -431,7 +431,7 @@ def get_existing_pdf_fields(
                 if field["all"].P.objgen == page.objgen:
                     i = idx
                     break
-            if i is -1:
+            if i == -1:
                 continue
         fields_in_pages[i].append(FormField.from_pikefield(field))
     return fields_in_pages
@@ -447,7 +447,8 @@ def swap_pdf_page(
 ) -> Pdf:
     """(DEPRECATED: use copy_pdf_fields) Copies the AcroForm fields from one PDF to another blank PDF form. Optionally, choose a starting page for both
     the source and destination PDFs. By default, it will remove any existing annotations (which include form fields)
-    in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`"""
+    in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`
+    """
     return copy_pdf_fields(
         source_pdf=source_pdf,
         destination_pdf=destination_pdf,
@@ -467,7 +468,8 @@ def copy_pdf_fields(
 ) -> Pdf:
     """Copies the AcroForm fields from one PDF to another blank PDF form. Optionally, choose a starting page for both
     the source and destination PDFs. By default, it will remove any existing annotations (which include form fields)
-    in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`"""
+    in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`
+    """
     if isinstance(source_pdf, (str, Path)):
         source_pdf = Pdf.open(source_pdf)
     if isinstance(destination_pdf, (str, Path)):

--- a/scripts/auto_fields_all.py
+++ b/scripts/auto_fields_all.py
@@ -1,20 +1,58 @@
 #!/usr/bin/env python3
 
-import sys
 import os
 import tempfile
 from pikepdf import Pdf
+import argparse
+import shutil
 
-from formfyxer.pdf_wrangling import auto_add_fields
+from pathlib import Path
+from enum import Enum
+import traceback
 
 
-def main():
+class ProcessingOption(Enum):
+    AUTO_ADD = "autoadd"
+    AUTO_AND_RELABEL = "autoandrelabel"
+    SCRAP_AND_AUTO = "scrapandauto"
+    NOTHING = "nothing"
+
+    def __str__(self):
+        return self.value
+
+
+def main() -> None:
     """Pass in an in-folder with PDFs, we'll strip off the fields and run our stuff over them"""
-    if len(sys.argv) < 3:
-        print("Need to pass in an in folder and a out folder!")
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-f",
+        "--fieldsredo",
+        type=str,
+        help="""
+      Determine what to do with fields. If "autoadd" (default), automatically adds fields when there
+      aren't any in the PDF. If "autoandrelabel", automatically adds fields, and renames
+      existing PDF fields using our ML. If "scrapandauto", it erases existing PDF fields and does auto add.
+      If "nothing", doesn't do anything, and will just copy all of the PDFs into another folder.
+      """,
+        default="autoadd",
+    )
+    parser.add_argument(
+        "in_folder",
+        type=str,
+        help="The input folder. All PDFs from this folder will be processed",
+    )
+    parser.add_argument("out_folder", type=str, help="The output folder")
+    args = parser.parse_args()
+    in_folder = args.in_folder
+    out_folder = args.out_folder
+    try:
+        p_option = ProcessingOption(
+            args.fieldsredo.lower().replace("-", "").replace("_", "")
+        )
+    except KeyError:
+        print(f"--fieldsredo needs to be a valid value (you passed {args.fieldsredo})")
         return
-    in_folder = sys.argv[1]
-    out_folder = sys.argv[2]
+
     to_process = sorted(
         [
             in_file
@@ -22,19 +60,51 @@ def main():
             if in_file.lower().endswith(".pdf")
         ]
     )
+
+    out_path = Path(out_folder)
+    if not Path(out_folder).exists():
+        out_path.mkdir(parents=True)
     for in_file in to_process:
+        in_path = in_folder + "/" + in_file
+        print(f"Starting on {in_path}")
         try:
-            p = Pdf.open(in_folder + "/" + in_file)
-            print(f"Starting on {in_file}")
-            p.Root.AcroForm = []
-            for page in p.pages:
-                page.Annots = []
-            tmp_file = tempfile.NamedTemporaryFile()
-            p.save(tmp_file.name)
-            tmp_file.flush()
-            auto_add_fields(tmp_file.name, out_folder + "/" + in_file)
+            if p_option in [
+                ProcessingOption.AUTO_ADD,
+                ProcessingOption.AUTO_AND_RELABEL,
+            ]:
+                from formfyxer.pdf_wrangling import (
+                    auto_add_fields,
+                    get_existing_pdf_fields,
+                    auto_rename_fields,
+                )
+
+                all_fields = [
+                    f
+                    for f_in_page in get_existing_pdf_fields(in_path)
+                    for f in f_in_page
+                ]
+                if not all_fields:
+                    auto_add_fields(in_path, out_folder + "/" + in_file)
+                else:
+                    if p_option == ProcessingOption.AUTO_AND_RELABEL:
+                        auto_rename_fields(in_path, out_folder + "/" + in_file)
+                    else:
+                        shutil.copyfile(in_path, out_folder + "/" + in_file)
+            elif p_option == ProcessingOption.SCRAP_AND_AUTO:
+                from formfyxer.pdf_wrangling import get_existing_pdf_fields
+
+                p = Pdf.open(in_path)
+                p.Root.AcroForm = []
+                for page in p.pages:
+                    page.Annots = []
+                tmp_file = tempfile.NamedTemporaryFile()
+                p.save(tmp_file.name)
+                tmp_file.flush()
+                auto_add_fields(tmp_file.name, out_folder + "/" + in_file)
+            else:
+                shutil.copyfile(in_path, out_folder + "/" + in_file)
         except Exception as ex:
-            print(f"Got exception for {in_file}: {ex}")
+            print(f"Got exception for {in_file}: {ex}, {traceback.format_exc()}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Use FormField objects when possible, instead of passing around
  raw Pike pdf objects
  * be gets font size from DA (PDF spec 12.7.3.2)
* group fields by page (needed to match fields to surrounding text)
* filter out fields without a page, or with a Template page (PDF spec 12.7.6)
* make names longer when reading them (PDF spec 12.7.3.2)
* improve auto_fields_all.py, with proper arguments and everything
  * lets you take all PDF in a folder and either
    * add fields if there aren't any
    * add fields if there aren't any and relabel existing fields
    * scrap existing fields and add fields back with our recognition
    * do nothing: just copy the PDFs
    
Current at 9a/ff of all forms, will need to re-run ~200 or so that errored out, and then will make another PR adding the stats generator.
   
Also, Fix #32, was low hanging fruit.