### PR TITLE
Improve complexity score coverage

### DIFF
--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -1314,7 +1314,7 @@ def _form_complexity_per_metric(stats):
             val -= metric["intercept"]
         return val * weight
 
-    return [(m["name"], stats.get(m["name"], 0), weight(stats, m)) for m in metrics]
+    return [(m["name"], stats[m["name"]], weight(stats, m)) for m in metrics]
 
 
 def form_complexity(stats):

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -1258,6 +1258,7 @@ def _form_complexity_per_metric(stats):
         # percents will have a higher weight, because they are between 0 and 1
         {"name": "slotin percent", "weight": 2},
         {"name": "gathered percent", "weight": 5},
+        {"name": "third party percent", "weight": 10},
         {"name": "created percent", "weight": 20},
         {"name": "passive voice percent", "weight": 4},
         {"name": "all caps percent", "weight": 10},


### PR DESCRIPTION
Add in two important factors to the overall score:

1. The average length of expected answers in characters. I checked on the civil docketing statement and it scored ~ 7.5, so I am using a weight of 1/8th for now.
2. The third party percentage, which looks like it was accidentally left out. 

Fix #87 Fix #88