### PR TITLE
Force reportlab to use latest security patch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     packages=['formfyxer'],
     install_requires=['spacy', 'pdfminer.six', 'pandas', 'pikepdf',
         'textstat', 'requests', 'numpy', 'scikit-learn', 'networkx', 'joblib',
-        'nltk', 'boxdetect', 'pdf2image', 'reportlab', 'pdfminer.six',
+        'nltk', 'boxdetect', 'pdf2image', 'reportlab>=3.6.13', 'pdfminer.six',
         'opencv-python', 'ocrmypdf', 'eyecite', 'passivepy>=0.2.16', 'sigfig',
         'typer>=0.4.1,<0.5.0', # typer pre 0.4.1 was broken by click 8.1.0: https://github.com/explosion/spaCy/issues/10564
         'openai', 'transformers' 


### PR DESCRIPTION
From the reportlab mailing list:

    These fix a potential security vulnerability in the parsing of colours.
    Previously, Iif someone had coded an application allowing user-input
    expressions to be passed to our toColor constructor function, there was a
    way to execute inappropriate code.  If you are doing this, please upgrade
    to the newest version.
    
I don't think we use it, but better to be safe IMO.