### PR TITLE
don't parse [] terms in YAML, allow overwrite of PDF

### DIFF
--- a/formfyxer/data/simplified_words.yml
+++ b/formfyxer/data/simplified_words.yml
@@ -28,7 +28,7 @@ added: "[more, other]"
 additional: "[extra, more, other]"
 addressees are requested: (omit)
 addressees: you
-adequate: [enough, sufficient]
+adequate: "[enough, sufficient]"
 adjacent to: next to
 adjacent: next to
 adjustment: "[change, alteration]"
@@ -113,7 +113,7 @@ complete: "[fill in, finish]"
 completion: end
 comply with: "[follow, keep to, meet]"
 component: part
-comprehend: [understand, grasp]
+comprehend: "[understand, grasp]"
 comprise form: "[include, make up]"
 comprises: "[is made up of, includes]"
 compulsory: you must
@@ -180,7 +180,7 @@ during which time: while
 dwelling: home
 economical: "[cheap, good value]"
 effect modifications: "[make changes]"
-elaborate: [explain, describe, develop]
+elaborate: "[explain, describe, develop]"
 elect: "[choose, pick]"
 eligible: "[allowed, qualified]"
 eliminate: "[cut, drop, end]"
@@ -215,7 +215,7 @@ excessive: "[too many, too much]"
 exclude: leave out
 excluding: "[apart from, except]"
 exclusively: only
-exemplify: [show, demonstrate, represent]
+exemplify: "[show, demonstrate, represent]"
 exempt from: free from
 exhibit: "[show, exhibit]"
 expedite: "[hurry, speed up, hasten]"
@@ -261,7 +261,7 @@ has a requirement for: needs
 has regard to: takes into account
 have regard to: take into account
 have the authority to: may
-hence: [so, therefore, as a result]
+hence: "[so, therefore, as a result]"
 henceforth: "[from now on, from today]"
 hereby: "[now, by this, (omit)]"
 herein: "[here, (omit)]"
@@ -327,7 +327,7 @@ inform: tell
 initial: first
 initially: at first
 initiate: "[begin, start]"
-inquire: [ask, question, investigate]
+inquire: "[ask, question, investigate]"
 insert: put in
 instances: cases
 intend to: will
@@ -409,7 +409,7 @@ partially: partly
 participate: "[join in, take part]"
 particulars: "[details, facts]"
 per annum: a year
-perceive: [see, notice, understand]
+perceive: "[see, notice, understand]"
 perform: do
 permissible: allowed
 permit: "[let, allow]"
@@ -554,7 +554,7 @@ utilization: use
 utilize: use
 validate: confirm
 variation: change
-verify: [check, confirm, make sure]
+verify: "[check, confirm, make sure]"
 viable: "[practical, workable]"
 vice: "[instead of, versus]"
 virtually: "[almost, (omit)]"

--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -347,7 +347,7 @@ def set_fields(
     if not fields_per_page:
         # Nothing to do, lol
         return
-    in_pdf = Pdf.open(in_file)
+    in_pdf = Pdf.open(in_file, allow_overwriting_input=overwrite)
     if hasattr(in_pdf.Root, "AcroForm") and not overwrite:
         print("Not going to overwrite the existing AcroForm!")
         return None


### PR DESCRIPTION
Hotfix for two errors:

- simplified_terms.yml included some bracketed terms, which get parsed as a list. They needed to be quoted.

- set_fields() had an `overwrite` parameter that wasn't being correctly used