### PR TITLE
If the PDF has no text, OCR it

### DIFF
--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -1095,7 +1095,7 @@ def parse_form(
     except:
         readability = -1
     # Still attempt to re-evaluate if not using openai
-    if (openai_creds and description == "abortthisnow.") or readability > 30:
+    if not original_text or (openai_creds and description == "abortthisnow.") or readability > 30:
         # We do not care what the PDF output is, doesn't add that much time
         ocr_p = [
             "ocrmypdf",


### PR DESCRIPTION
Looks like this was an oversight originally. We already invoke OCRMyPDF if we get garbage readability results or if OpenAI fails. This adds an OCR pass if there is no text layer in the PDF.

See: https://github.com/SuffolkLITLab/RateMyPDF/issues/6