### PR TITLE
Remove use of pickled (joblib) files for now

### DIFF
--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -422,7 +422,7 @@ def normalize_name(
         this_field = regex_norm_field(this_field)
 
     if this_field in included_fields:
-        return f"*{this_field}", 1.0
+        return f"*{this_field}", 0.01
     
     return reformat_field(this_field, tools_token=tools_token), 0.5
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class InstallSpacyModelCommand(install):
 
 setuptools.setup(
     name='formfyxer',
-    version='0.2.0',
+    version='0.3.0a1',
     author='Suffolk LIT Lab',
     author_email='litlab@suffolk.edu',
     description='A tool for learning about and pre-processing pdf forms.',


### PR DESCRIPTION
pickling broke stuff when package versions changed; docassemble's packages depend on new versions and the pickled stuff was generated with an old version.

Once this is merged, we need to create associated PyPI package and set it as a dependency of the Weaver so installing the Weaver will use the fixed version of FormFyxer.

This is just a temporary fix. Long-term, we will:

1. Figure out a simpler to update way to store the list of known field names, nouns for people, and rules for suffixes appended to people nouns. I suggest a YAML or JSON file.
2. Switch to LLM-driven field normalization. This appears likely to perform a lot better. We can combine w/ the list of known field names.

Note the typing error isn't related to the changed code. I'll open a separate issue for that (#120). possibly was due to a change in mypy and not our code base?