### PR TITLE
Safer checking for field annotations in a PDF

### DIFF
--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -444,8 +444,11 @@ def has_fields(pdf_file: str) -> bool:
         for page in pdf.pages:
             if "/Annots" in page:
                 for annot in page.Annots:  # type: ignore
-                    if annot.Type == "/Annot" and annot.Subtype == "/Widget":
-                        return True
+                    try:
+                        if annot.Type == "/Annot" and annot.Subtype == "/Widget":
+                            return True
+                    except:
+                        continue
     return False
 
 


### PR DESCRIPTION
Not all annotations have Types and Subtypes, so don't throw exceptions if we come across those annotations, just skip them.

Fixes #118 