### PR TITLE
Migrate to the stable OpenAI Python client (1.0)

### DIFF
--- a/formfyxer/keys/openai_key.txt
+++ b/formfyxer/keys/openai_key.txt
@@ -1,1 +1,0 @@
-your_OPENAI_API_key goes here

--- a/formfyxer/keys/openai_org.txt
+++ b/formfyxer/keys/openai_org.txt
@@ -1,1 +1,0 @@
-your_OPENAI_API_org goes here

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -131,18 +131,18 @@ try:
     with open(
         os.path.join(os.path.dirname(__file__), "keys", "openai_key.txt"), "r"
     ) as in_file:
-        default_key = OpenAI(api_key=in_file.read().rstrip())
+        default_key:Optional[str] = in_file.read().rstrip()
 except:
     default_key = None
 try:
     with open(
         os.path.join(os.path.dirname(__file__), "keys", "openai_org.txt"), "r"
     ) as in_file:
-        default_org = in_file.read().rstrip()
+        default_org:Optional[str] = in_file.read().rstrip()
 except:
     default_org = None
 if default_key:
-    client = OpenAI(api_key=default_key, organization=default_org or None)
+    client:Optional[OpenAI] = OpenAI(api_key=default_key, organization=default_org or None)
 elif os.getenv("OPENAI_API_KEY"):
     client = OpenAI()
 else:
@@ -828,7 +828,10 @@ def text_complete(prompt:str, max_tokens:int=500, creds: Optional[OpenAiCreds] =
     if creds:
         openai_client = OpenAI(api_key=creds["key"], organization=creds["org"])
     else:
-        openai_client = client
+        if client:
+            openai_client = client
+        else:
+            raise Exception("No OpenAI credentials provided")
     try:
         response = openai_client.chat.completions.create(
             model="gpt-3.5-turbo",
@@ -844,7 +847,7 @@ def text_complete(prompt:str, max_tokens:int=500, creds: Optional[OpenAiCreds] =
             frequency_penalty=0.0,
             presence_penalty=0.0
         )
-        return str(response.choices[0].message.content.strip())
+        return str((response.choices[0].message.content or "").strip())
     except Exception as ex:
         print(f"{ex}")
         return "ApiError"

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -65,6 +65,8 @@ from typing import (
 )
 
 import openai
+from openai import OpenAI
+
 from transformers import GPT2TokenizerFast
 
 tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
@@ -125,14 +127,27 @@ with open(
     os.path.join(os.path.dirname(__file__), "keys", "spot_token.txt"), "r"
 ) as in_file:
     default_spot_token = in_file.read().rstrip()
-with open(
-    os.path.join(os.path.dirname(__file__), "keys", "openai_org.txt"), "r"
-) as in_file:
-    openai.organization = in_file.read().rstrip()
-with open(
-    os.path.join(os.path.dirname(__file__), "keys", "openai_key.txt"), "r"
-) as in_file:
-    openai.api_key = in_file.read().rstrip()
+try:
+    with open(
+        os.path.join(os.path.dirname(__file__), "keys", "openai_key.txt"), "r"
+    ) as in_file:
+        default_key = OpenAI(api_key=in_file.read().rstrip())
+except:
+    default_key = None
+try:
+    with open(
+        os.path.join(os.path.dirname(__file__), "keys", "openai_org.txt"), "r"
+    ) as in_file:
+        default_org = in_file.read().rstrip()
+except:
+    default_org = None
+if default_key:
+    client = OpenAI(api_key=default_key, organization=default_org or None)
+elif os.getenv("OPENAI_API_KEY"):
+    client = OpenAI()
+else:
+    client = None
+
 
 # TODO(brycew): remove by retraining the model to work with random_state=4.
 NEEDS_STABILITY = True if os.getenv("ISUNITTEST") else False
@@ -801,22 +816,35 @@ class OpenAiCreds(TypedDict):
     key: str
 
 
-def text_complete(prompt, max_tokens=500, creds: Optional[OpenAiCreds] = None) -> str:
-    if creds:
-        openai.organization = creds["org"].strip() or ""
-        openai.api_key = creds["key"].strip() or ""
+def text_complete(prompt:str, max_tokens:int=500, creds: Optional[OpenAiCreds] = None, temperature:float=0) -> str:
+    """Run a prompt via openAI's API and return the result.
 
+    Args:
+        prompt (str): The prompt to send to the API.
+        max_tokens (int, optional): The number of tokens to generate. Defaults to 500.
+        creds (Optional[OpenAiCreds], optional): The credentials to use. Defaults to None.
+        temperature (float, optional): The temperature to use. Defaults to 0.
+    """
+    if creds:
+        openai_client = OpenAI(api_key=creds["key"], organization=creds["org"])
+    else:
+        openai_client = client
     try:
-        response = openai.Completion.create(
-            model="text-davinci-003",
-            prompt=prompt,
-            temperature=0,
+        response = openai_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system", 
+                    "content": prompt
+                },
+            ],
+            temperature=temperature,
             max_tokens=max_tokens,
             top_p=1.0,
             frequency_penalty=0.0,
-            presence_penalty=0.0,
+            presence_penalty=0.0
         )
-        return str(response["choices"][0]["text"].strip())
+        return str(response.choices[0].message.content.strip())
     except Exception as ex:
         print(f"{ex}")
         return "ApiError"

--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -1232,15 +1232,20 @@ def get_possible_text_fields(
         if method == "top-to-bottom" or method == "bottom-to-top":
             coord = 1
         # construct list of bounding boxes and sort them top to bottom
-        boundingBoxes = [cv2.boundingRect(c) for c in cnts]
+        boundingBoxes = tuple(cv2.boundingRect(c) for c in cnts)
         if not boundingBoxes:
-            return [[], []]
-        (cnts, boundingBoxes) = zip(
-            *sorted(
-                zip(cnts, boundingBoxes), key=lambda b: b[1][coord], reverse=reverse
-            )
-        )
-        # return the list of sorted contours and bounding boxes
+            return (),()
+
+        # Sort the contours and bounding boxes
+        sorted_zip = sorted(zip(cnts, boundingBoxes), key=lambda b: b[1][coord], reverse=reverse)
+
+        # If sorted_zip is empty, return empty lists
+        if not sorted_zip:
+            return (), ()
+
+        # Unpack the sorted contours and bounding boxes, and convert to lists
+        cnts, boundingBoxes = zip(*sorted_zip)
+
         return (cnts, boundingBoxes)
 
     (contours, boundingBoxes) = sort_contours(contours, method="top-to-bottom")

--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -1231,7 +1231,7 @@ def get_possible_text_fields(
         # handle sorting against the y-coord rather than the x-coord of the bounding box
         if method == "top-to-bottom" or method == "bottom-to-top":
             coord = 1
-        # construct list of bounding boxes and sort them top to bottom
+        # construct tuple of bounding boxes and sort them top to bottom
         boundingBoxes = tuple(cv2.boundingRect(c) for c in cnts)
         if not boundingBoxes:
             return (),()
@@ -1239,11 +1239,10 @@ def get_possible_text_fields(
         # Sort the contours and bounding boxes
         sorted_zip = sorted(zip(cnts, boundingBoxes), key=lambda b: b[1][coord], reverse=reverse)
 
-        # If sorted_zip is empty, return empty lists
         if not sorted_zip:
             return (), ()
 
-        # Unpack the sorted contours and bounding boxes, and convert to lists
+        # Unpack the sorted contours and bounding boxes
         cnts, boundingBoxes = zip(*sorted_zip)
 
         return (cnts, boundingBoxes)


### PR DESCRIPTION
A simple migration of text_complete() code to the stable OpenAI 1.0 release.

1. I made the default OpenAI text files empty, rather than putting in placeholder text. Currently, if you use the empty OpenAI() initialization with an invalid API key, it will raise an error right away. This solves that issue.
2. This now works with an environment variable, which is the expected way that OpenAI documents to provide an API key in the new client.
3. It still allows you to pass the credentials manually, so it should be compatible with the previous code we had.

@BryceStevenWilley I don't know why, but some new typing issues cropped up with your field recognition code. Shouldn't have mattered at run time (we weren't doing anything that depended on lists or tuples), but perhaps a new mypy release is stricter. To solve the typing error message, I made sure we use tuples rather than lists for the internal function I modified below. It should be identical, but please take a look. Using tuples everywhere, including default returns, seemed a better option than converting the outputs to a list.