### PR TITLE
Fix mypy typing issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-20.04
     steps:
-    - uses: SuffolkLITLab/ALActions/publish@fix_numpy_pt2
+    - uses: SuffolkLITLab/ALActions/publish@main
       with:
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         VERSION_TO_PUBLISH: ${{ env.GITHUB_REF_NAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-20.04
     steps:
-    - uses: SuffolkLITLab/ALActions/publish@main
+    - uses: SuffolkLITLab/ALActions/publish@fix_numpy_pt2
       with:
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         VERSION_TO_PUBLISH: ${{ env.GITHUB_REF_NAME }}

--- a/formfyxer/docx_wrangling.py
+++ b/formfyxer/docx_wrangling.py
@@ -51,8 +51,8 @@ def add_run_after(run, text):
 
 
 def update_docx(
-    document: Union[docx.Document, str], modified_runs: List[Tuple[int, int, str, int]]
-) -> docx.Document:
+    document: Union[docx.document.Document, str], modified_runs: List[Tuple[int, int, str, int]]
+) -> docx.document.Document:
     """Update the document with the modified runs.
 
     Note: OpenAI is probabilistic, so the modified run indices may not be correct. 
@@ -416,7 +416,7 @@ def get_modified_docx_runs(
     guesses = json.loads(response.choices[0].message.content)["results"]
     return guesses
 
-def make_docx_plain_language(docx_path: str) -> docx.Document:
+def make_docx_plain_language(docx_path: str) -> docx.document.Document:
     """
     Convert a DOCX file to plain language with the help of OpenAI.
     """
@@ -443,7 +443,7 @@ def make_docx_plain_language(docx_path: str) -> docx.Document:
     )
     return update_docx(docx.Document(docx_path), guesses)
 
-def modify_docx_with_openai_guesses(docx_path: str) -> docx.Document:
+def modify_docx_with_openai_guesses(docx_path: str) -> docx.document.Document:
     """Uses OpenAI to guess the variable names for a document and then modifies the document with the guesses.
 
     Args:

--- a/formfyxer/pdf_wrangling.py
+++ b/formfyxer/pdf_wrangling.py
@@ -1152,8 +1152,8 @@ def get_possible_radios(img: Union[str, BinaryIO, cv2.Mat]):
         maxRadius=50,
     )
     if circles is not None:
-        circles = np.uint16(np.around(circles))
-        for i in circles[0, :]:
+        rounded_circles = np.around(circles)
+        for i in rounded_circles[0, :]:
             center = (i[0], i[1])
             # circle center
             cv2.circle(img_mat, center, 1, (0, 100, 100), 3)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     license='MIT',
     packages=['formfyxer'],
     install_requires=['spacy', 'pdfminer.six', 'pandas', 'pikepdf',
-        'textstat', 'requests', 'numpy', 'scikit-learn==1.2.2', 'networkx', 'joblib',
+        'textstat', 'requests', 'numpy<2.0.0', 'scikit-learn==1.2.2', 'networkx', 'joblib',
         'nltk', 'boxdetect', 'pdf2image', 'reportlab>=3.6.13', 'pdfminer.six',
         'opencv-python', 'ocrmypdf', 'eyecite', 'passivepy>=0.2.16', 'sigfig',
         'typer>=0.4.1,<0.5.0', # typer pre 0.4.1 was broken by click 8.1.0: https://github.com/explosion/spaCy/issues/10564


### PR DESCRIPTION
Numpy 2.0 released and can cause some potential issues, so restrict to 1.x.y for now.

* `docx.Document` is a constructor function, `docx.document.Document` is the type itself
* Some unused weirdness in `get_possible_radios` popped up: the function is untested, so I fixed the typing issues

If this passes, I'll merge and then merge some fixes into `pdf_content_extract` and #134. 