### PR TITLE
quick and dirty patch

### DIFF
--- a/dev-testing/functions.ipynb
+++ b/dev-testing/functions.ipynb
@@ -2,68 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "id": "cc93a668",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "daa35a202b9944a981d2163df1c63c60",
+       "model_id": "5bd625018f6247fab661ce6d838cb40c",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Downloading:   0%|          | 0.00/1.04M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bebdf1cab3a0459d8287208bd0923907",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/456k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "292dc7fa30e14ed29d3fd1c547a1c121",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/1.36M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c8b65b559f5e42dc9c3015181358047b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/665 [00:00<?, ?B/s]"
+       "Downloading:   0%|          | 0.00/26.0 [00:00<?, ?B/s]"
       ]
      },
      "metadata": {},
@@ -139,31 +90,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 2,
    "id": "e158174f",
    "metadata": {},
    "outputs": [],
    "source": [
     "stop_words = set(stopwords.words(\"english\"))\n",
     "\n",
-    "try:\n",
-    "    # this takes a while to load\n",
-    "    import en_core_web_lg\n",
+    "if 1==2:\n",
+    "    try:\n",
+    "        # this takes a while to load\n",
+    "        import en_core_web_lg\n",
     "\n",
-    "    nlp = en_core_web_lg.load()\n",
-    "except:\n",
-    "    print(\"Downloading word2vec model en_core_web_lg\")\n",
-    "    import subprocess\n",
+    "        nlp = en_core_web_lg.load()\n",
+    "    except:\n",
+    "        print(\"Downloading word2vec model en_core_web_lg\")\n",
+    "        import subprocess\n",
     "\n",
-    "    bashCommand = \"python -m spacy download en_core_web_lg\"\n",
-    "    process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)\n",
-    "    output, error = process.communicate()\n",
-    "    print(f\"output of word2vec model download: {str(output)}\")\n",
-    "    import en_core_web_lg\n",
+    "        bashCommand = \"python -m spacy download en_core_web_lg\"\n",
+    "        process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)\n",
+    "        output, error = process.communicate()\n",
+    "        print(f\"output of word2vec model download: {str(output)}\")\n",
+    "        import en_core_web_lg\n",
     "\n",
-    "    nlp = en_core_web_lg.load()\n",
+    "        nlp = en_core_web_lg.load()\n",
     "\n",
-    "passivepy = PassivePy.PassivePyAnalyzer(nlp=nlp)"
+    "    passivepy = PassivePy.PassivePyAnalyzer(nlp=nlp)"
    ]
   },
   {
@@ -198,6 +150,8 @@
     "jurisdictions = load(\"../formfyxer/data/jurisdictions.joblib\")\n",
     "groups = load(\"../formfyxer/data/groups.joblib\")\n",
     "clf_field_names = load(\"../formfyxer/data/clf_field_names.joblib\")\n",
+    "with open(\"../../keys/tools_token.txt\", \"r\") as file:\n",
+    "    tools_token = file.read().rstrip()\n",
     "with open(\"../../keys/spot_token.txt\", \"r\") as file:\n",
     "    spot_token = file.read().rstrip()\n",
     "with open(\"../../keys/openai_org.txt\", \"r\") as file:\n",
@@ -3045,7 +2999,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3059,7 +3013,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   },
   "vscode": {
    "interpreter": {

--- a/dev-testing/test package.ipynb
+++ b/dev-testing/test package.ipynb
@@ -10,7 +10,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
+   "id": "064702eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install update openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
    "id": "10339cb6",
    "metadata": {},
    "outputs": [],
@@ -19,6 +29,16 @@
     "\n",
     "sys.path.insert(0, \"../../formfyxer\")\n",
     "import formfyxer.lit_explorer as ff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8bba1e11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tools_token=\"your token here\""
    ]
   },
   {
@@ -61,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "id": "f1524626",
    "metadata": {},
    "outputs": [
@@ -71,7 +91,7 @@
        "'Reformat snake case, camel Case and similarly formated text into individual words.'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -84,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "45ee2f7d",
    "metadata": {},
    "outputs": [
@@ -94,7 +114,7 @@
        "'users1_name'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -105,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "8d056f9c",
    "metadata": {},
    "outputs": [
@@ -115,49 +135,49 @@
        "'variable_fill_name'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ff.reformat_field(\"this is a variable where you fill out your name\")"
+    "ff.reformat_field(\"this is a variable where you fill out your name\", tools_token=tools_token)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "6bd4f593",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "('case_number', 0.31)"
+       "('case_number', 0.5)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ff.normalize_name(\"UT\", None, 2, 0.3, \"null\", \"Case Number\")"
+    "ff.normalize_name(\"UT\", None, 2, 0.3, \"null\", \"Case Number\", tools_token=tools_token)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "id": "30a1f1b6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"Approved, SCAO\\n\\nSTATE OF MICHIGAN\\n\\nJUDICIAL CIRCUIT\\nCOUNTY\\n\\nOriginal - Court\\n1st copy - Moving party\\n2nd copy - Objecting party\\n\\n3rd copy - Friend of the court\\n4th copy - Proof of service\\n5th copy - Proof of service\\n\\nA\\n\\nCASE NO.\\n\\nOBJECTION TO PROPOSED ORDER\\n\\nCourt  address\\n\\nCourt  telephone  no.\\n\\nPlaintiff's name, address, and telephone no.\\n\\nmoving party\\n\\nDefendant's name, address, and telephone no.\\n\\nmoving party\\n\\nv\\n\\nThird party's name, address, and telephone no.\\n\\nmoving party\\n\\nI received a notice to enter a proposed order without a hearing dated\\nI object to the entry of the proposed order and request a hearing by the court.  My objection is based on the following reason(s):\\n\\nC\\n\\nB\\n\\nD\\n\\nE\\n\\nDate\\n\\nMoving party's signature\\n\\nName (type or print)\\n\\nCERTIFICATE OF MAILING\\n\\nI certify that on this date I served a copy of this objection on the parties or their attorneys by first-class mail addressed to their\\nlast-known addresses as defined in MCR 3.203.\\n\\nF\\n\\nDate\\n\\nSignature of objecting party\\n\\nFOC 78   (3/11)   OBJECTION TO PROPOSED ORDER\\n\\nMCR 2.602(B)\\n\\n\\x0c\""
+       "\"Approved, SCAO\\n\\nSTATE OF MICHIGAN\\n\\nJUDICIAL CIRCUIT\\nCOUNTY\\n\\nOriginal - Court\\n1st copy - Moving party\\n2nd copy - Objecting party\\n\\n3rd copy - Friend of the court\\n4th copy - Proof of service\\n5th copy - Proof of service\\n\\nA\\n\\nCASE NO.\\n\\nOBJECTION TO PROPOSED ORDER\\n\\nCourt  address\\n\\nCourt  telephone  no.\\n\\nPlaintiff's name, address, and telephone no.\\n\\nmoving party\\n\\nDefendant's name, address, and telephone no.\\n\\nmoving party\\n\\nv\\n\\nThird party's name, address, and telephone no.\\n\\nmoving party\\n\\nI received a notice to enter a proposed order without a hearing dated\\nI object to the entry of the proposed order and request a hearing by the court.  My objection is based on the following reason(s):\\n\\nC\\n\\nMoving party's signature\\n\\nName (type or print)\\n\\nCERTIFICATE OF MAILING\\n\\nSignature of objecting party\\n\\nI certify that on this date I served a copy of this objection on the parties or their attorneys by first-class mail addressed to their\\nlast-known addresses as defined in MCR 3.203.\\n\\nFOC 78   (3/11)   OBJECTION TO PROPOSED ORDER\\n\\nMCR 2.602(B)\\n\\nB\\n\\nD\\n\\nE\\n\\nDate\\n\\nF\\n\\nDate\\n\\n\\x0c\""
       ]
      },
-     "execution_count": 18,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -168,21 +188,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "98d71551",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Error'"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ff.guess_form_name(\n",
     "    ff.extract_text(\"ML_training/auto/095b9dc651ce47eb8b62e0790974970f.pdf\")\n",
@@ -191,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "f6dc060a",
    "metadata": {
     "scrolled": true
@@ -200,95 +209,95 @@
     {
      "data": {
       "text/plain": [
-       "array([-5.26231120e-04,  2.24983986e-03, -8.35795340e-03,  4.02475413e-03,\n",
-       "        3.44079169e-03, -3.62503832e-03,  4.91300346e-04, -1.02481993e-02,\n",
-       "       -8.75018570e-05,  5.77801012e-02, -8.04772768e-03,  1.93668896e-03,\n",
-       "        1.61031034e-03, -4.88554112e-03, -7.56827288e-03, -3.22198853e-04,\n",
-       "        1.72684901e-03,  1.09334913e-02, -2.45365698e-03,  2.60785779e-03,\n",
-       "        3.31795751e-03, -1.82501888e-03, -5.17577020e-04,  9.05366796e-04,\n",
-       "       -1.88947119e-03, -1.41778216e-03, -2.19670966e-03, -2.33783632e-03,\n",
-       "        1.00638480e-03, -6.26632172e-03, -5.01368841e-04,  7.08620072e-03,\n",
-       "       -3.12600359e-03,  6.44426321e-03,  2.27485859e-04,  8.98271860e-04,\n",
-       "       -2.61456956e-03, -6.52393141e-04, -1.24109763e-03, -3.89325497e-03,\n",
-       "       -3.06367232e-03, -1.28471724e-03, -2.69054515e-03, -3.91209299e-03,\n",
-       "        1.32449560e-03,  4.50141250e-03, -1.75082921e-03, -3.78464401e-03,\n",
-       "        1.40550716e-03,  2.89970543e-03, -2.89665523e-03,  2.99134455e-03,\n",
-       "       -4.17377978e-03,  2.69617527e-03, -1.59275456e-04, -7.83068891e-04,\n",
-       "       -6.36623462e-04, -2.48208915e-03, -1.25590225e-03, -2.50187579e-04,\n",
-       "       -2.05267708e-03, -2.68196150e-03, -4.38043172e-05,  4.18123381e-03,\n",
-       "        6.31226077e-03, -3.65403513e-03,  2.65449648e-03,  2.05167042e-04,\n",
-       "       -1.30922426e-03,  8.00734152e-03,  1.38796774e-03,  1.76862839e-03,\n",
-       "        7.66475223e-03,  8.80032085e-04,  2.59798026e-03,  3.22615966e-03,\n",
-       "        9.56395168e-03, -4.76434876e-03, -4.72719918e-03,  6.81382797e-03,\n",
-       "       -4.05296658e-03,  8.91728523e-03, -4.68128831e-03, -5.16060328e-03,\n",
-       "        1.66344554e-03,  2.91576202e-03,  7.22084550e-03, -5.06330498e-03,\n",
-       "        1.33031214e-02,  4.79664028e-03, -1.07973688e-03,  3.88623763e-05,\n",
-       "       -1.23686194e-04,  3.57764797e-04,  2.40055549e-03,  1.39446255e-03,\n",
-       "        7.12260341e-03, -8.41163896e-04, -5.16814871e-04,  4.72550955e-03,\n",
-       "        1.33025948e-03, -4.51154774e-03,  8.67997034e-05, -5.33963124e-03,\n",
-       "       -2.16460094e-03, -1.51862293e-02,  5.61281296e-03,  4.78538005e-03,\n",
-       "       -4.88630835e-03, -2.68976954e-03,  6.91397406e-04, -7.68237538e-03,\n",
-       "        6.35172810e-03,  3.49582726e-04,  2.25623079e-03,  7.04172971e-04,\n",
-       "        3.25000592e-03, -1.08145548e-03,  5.15488738e-03, -2.57177091e-04,\n",
-       "        1.76189272e-03, -1.11836531e-04, -2.16169944e-04, -1.91144984e-03,\n",
-       "        3.43246164e-03,  3.58958300e-03, -5.56801994e-03,  1.46526319e-04,\n",
-       "       -3.65503599e-03,  1.21198749e-03, -4.71577666e-03,  1.32155107e-03,\n",
-       "       -7.55368584e-03,  4.21072481e-04,  3.84473030e-03,  7.37876031e-04,\n",
-       "        2.51003285e-03,  1.13599304e-02, -2.91033290e-03, -2.17953879e-03,\n",
-       "       -4.48384314e-02, -2.55559416e-03,  1.27762248e-03,  3.16679245e-04,\n",
-       "        1.73199350e-04,  1.50888037e-03, -4.79663957e-03,  5.17604744e-03,\n",
-       "       -3.98579436e-03, -1.39384994e-03, -1.60889822e-03,  6.14265860e-03,\n",
-       "        2.33297705e-04, -3.52656403e-04,  1.12852005e-03,  1.65170200e-03,\n",
-       "       -1.63151391e-03, -6.32309832e-04,  1.19076047e-03, -3.06317795e-03,\n",
-       "       -4.79622367e-03, -3.06260930e-04,  1.65514420e-03, -1.22830785e-03,\n",
-       "       -3.04184669e-03, -4.55402836e-03,  3.88777805e-03,  2.00426727e-03,\n",
-       "        2.14710762e-03,  1.68567815e-03, -6.47409360e-03, -6.46973133e-03,\n",
-       "       -5.74770121e-05, -5.43416808e-03, -6.19798278e-03, -1.14207302e-04,\n",
-       "       -1.01290520e-03,  9.50722038e-04, -4.10705805e-03,  4.52319444e-04,\n",
-       "        4.62367242e-03, -5.16681711e-03, -3.19836917e-03,  2.15407870e-03,\n",
-       "        2.97252097e-03,  1.56973282e-03, -3.55476436e-03,  1.62631717e-03,\n",
-       "        2.02915202e-03,  2.61959652e-03, -3.41814925e-04,  1.05913682e-03,\n",
-       "       -5.67106089e-03, -2.26600230e-04,  4.77448347e-04,  6.28645666e-03,\n",
-       "       -1.01146419e-03, -6.35369059e-03,  1.65369797e-04, -9.55562091e-04,\n",
-       "       -5.87664628e-03,  1.26514872e-03, -7.70650378e-03,  1.81958423e-03,\n",
-       "        1.19041591e-03,  3.69227689e-03,  6.81289417e-03,  2.34441887e-04,\n",
-       "        4.76372670e-03, -3.22644252e-03,  7.13130209e-04, -1.34127493e-03,\n",
-       "        3.49982077e-03,  3.36139797e-03, -2.95230863e-03,  5.77470678e-03,\n",
-       "       -1.91699363e-03, -1.58495209e-03, -1.37739101e-03,  2.91823707e-03,\n",
-       "       -2.54773333e-03,  1.70074190e-03, -9.05261306e-04, -1.14740142e-03,\n",
-       "        9.50051913e-04, -4.24206736e-03,  2.38089718e-04,  2.40279602e-03,\n",
-       "       -1.33007275e-03, -5.04937888e-03, -3.60123558e-03,  9.58420218e-04,\n",
-       "        3.30443339e-03,  1.58153860e-03,  4.72644728e-03, -3.60392571e-03,\n",
-       "       -3.44693427e-04, -2.36716859e-03,  4.83650924e-03,  2.43589561e-03,\n",
-       "        3.00392594e-03,  3.94615047e-03,  1.71704478e-03,  5.89554031e-03,\n",
-       "        2.18071977e-03, -6.37284036e-03,  5.64066123e-03, -4.59186528e-03,\n",
-       "       -1.58649190e-03,  6.56146175e-03, -1.04672343e-03, -6.28604576e-03,\n",
-       "       -7.47575222e-04,  2.12077705e-03,  5.26619347e-03,  2.89095824e-03,\n",
-       "       -1.62623299e-03, -5.51077501e-03, -9.67431517e-05,  3.44178292e-03,\n",
-       "       -6.74005028e-03,  3.24305482e-03,  1.03411332e-03, -1.69642029e-03,\n",
-       "        5.81055945e-03, -2.27511233e-03, -1.24854863e-03,  4.16209955e-04,\n",
-       "       -9.86948252e-04, -3.47459984e-03,  8.35964266e-03,  1.90435018e-03,\n",
-       "       -6.13537569e-04, -4.42874018e-03, -2.34987644e-03, -6.47533826e-04,\n",
-       "       -5.74400109e-03, -3.98190719e-03,  1.23454575e-03,  4.60058269e-03,\n",
-       "        1.13744318e-03, -1.43143558e-03, -3.46458480e-03,  1.70765680e-03,\n",
-       "       -5.39483022e-03, -2.10772697e-03,  9.33664766e-03, -2.98427860e-03,\n",
-       "       -6.75659472e-04, -3.30385404e-04, -3.49518099e-03,  1.54804617e-04,\n",
-       "        2.41326119e-03,  4.88547941e-03,  2.49007910e-03, -2.13324702e-04,\n",
-       "        5.94240817e-03,  4.13455749e-03,  1.64867480e-03, -1.49173268e-03])"
+       "array([ 3.91383841e-02,  3.74705766e-02, -9.98597692e-02, -1.14338996e-02,\n",
+       "       -6.12632310e-02,  2.95500084e-02, -2.66791423e-02,  6.50028908e-02,\n",
+       "       -6.16411376e-02,  9.50854852e-02,  8.02389349e-02,  4.57129042e-02,\n",
+       "       -7.21761292e-02,  2.12103883e-02,  2.60794196e-02, -5.79980208e-02,\n",
+       "        3.39355434e-02, -1.45301236e-01, -1.40438473e-02, -1.77644619e-02,\n",
+       "        6.08872548e-02, -8.12713371e-03,  4.68537477e-02, -1.70541425e-01,\n",
+       "        2.78735315e-03, -1.73112623e-02, -5.30503220e-02, -1.42496522e-02,\n",
+       "       -3.72042910e-02,  5.15232772e-02,  6.30143224e-03, -2.32950673e-02,\n",
+       "        1.36063259e-02,  8.02463305e-03, -4.58777597e-02,  1.99661904e-02,\n",
+       "        7.51623300e-03,  1.40369367e-02,  1.24910958e-01,  4.21865796e-02,\n",
+       "        1.89100541e-02,  4.91487659e-02,  2.90375418e-02, -5.07765084e-02,\n",
+       "        7.18243904e-02, -1.36731515e-02, -7.70340021e-02, -8.17896095e-02,\n",
+       "       -7.15626294e-02,  8.07250205e-02,  7.19660570e-02,  4.14691387e-04,\n",
+       "        1.60426911e-02, -2.17340353e-02, -1.42326794e-02, -4.22379647e-02,\n",
+       "        1.66823158e-02, -2.32781741e-02, -1.50226035e-02,  8.03480448e-02,\n",
+       "        6.81939680e-02, -2.97557149e-04, -4.91235781e-02,  1.16956606e-02,\n",
+       "       -4.82142564e-02, -3.87721087e-02, -3.67756289e-02, -6.40971947e-02,\n",
+       "       -3.71515635e-02,  2.76598092e-02, -1.60082898e-02,  5.59147332e-03,\n",
+       "       -1.73792341e-03,  5.69810198e-02,  8.02767828e-02, -4.97736814e-02,\n",
+       "       -1.06713768e-03,  1.81043698e-02,  3.88915962e-03, -8.22943080e-02,\n",
+       "       -8.91336366e-02,  4.47243492e-02,  1.07173469e-01, -3.98095353e-02,\n",
+       "       -4.87519415e-03,  3.18890357e-02, -1.20355918e-02,  4.47714914e-02,\n",
+       "       -4.44488465e-03, -2.44649153e-02,  2.67811064e-02,  1.81433961e-02,\n",
+       "        3.74274618e-02, -1.04727103e-01,  2.47865595e-02,  1.54953713e-02,\n",
+       "        6.03541886e-02,  3.04796724e-02,  9.08918603e-02, -7.42893988e-02,\n",
+       "       -3.05412801e-02,  5.99510942e-02,  2.54322289e-02, -5.52781889e-02,\n",
+       "        5.52932203e-02,  3.50736652e-02, -7.26478890e-02,  5.22613006e-02,\n",
+       "       -1.19346947e-01,  1.99804159e-02, -7.50037090e-02, -3.41040122e-02,\n",
+       "        7.63052288e-02,  1.11827837e-02,  3.30853258e-02,  9.51524994e-02,\n",
+       "       -2.81973877e-02, -9.97181271e-02,  6.74807308e-02, -4.57862276e-03,\n",
+       "       -8.98553511e-03, -2.04339829e-02, -1.12282383e-01,  6.45397883e-02,\n",
+       "        3.60455450e-02,  1.39132255e-01,  7.95307930e-02,  2.28512367e-02,\n",
+       "       -1.98707143e-02, -2.56168879e-02, -3.81680690e-03, -2.08723899e-02,\n",
+       "        2.23600581e-02, -4.96530627e-02,  2.97667634e-02, -7.79312099e-03,\n",
+       "       -3.05205262e-02, -6.89185523e-02,  1.19034747e-01, -7.71992741e-02,\n",
+       "       -8.64508150e-02, -2.21449002e-02,  6.16324607e-03, -2.07479790e-02,\n",
+       "       -3.14207251e-02,  8.66738486e-03, -6.96599367e-02,  4.85024400e-02,\n",
+       "        4.68090748e-02, -6.46374434e-02, -1.93630798e-02,  6.16414316e-02,\n",
+       "       -1.61690299e-02,  3.94988695e-03, -1.21530679e-03,  1.86681504e-02,\n",
+       "        3.60062468e-02, -4.24863699e-02, -7.95422919e-02,  7.99356157e-03,\n",
+       "       -2.17092988e-03, -8.46349056e-02, -6.53552420e-02,  4.19019824e-02,\n",
+       "       -4.79916613e-02,  9.00222068e-03,  5.47984774e-02,  5.43282658e-02,\n",
+       "       -3.87653867e-02, -5.51063125e-02,  6.56543219e-02, -1.82817789e-02,\n",
+       "        3.18959438e-02,  8.40516694e-02,  1.10980336e-02, -5.28996993e-02,\n",
+       "       -5.97978013e-02,  4.78927323e-02,  9.55837949e-02, -6.54040647e-02,\n",
+       "        9.22715650e-03,  1.41443148e-02,  1.36193125e-01,  5.75328164e-02,\n",
+       "       -3.85482391e-03, -3.80056099e-02, -7.52123889e-05, -8.76829591e-02,\n",
+       "        2.11783314e-02,  3.27018682e-02, -1.10821363e-02,  1.22104691e-01,\n",
+       "       -7.74100518e-02, -1.00575172e-01, -8.50201368e-02, -1.03598934e-01,\n",
+       "       -3.22513915e-02,  1.17758873e-02, -1.86052309e-02,  8.06930812e-02,\n",
+       "       -7.63197017e-02, -2.26206261e-02, -9.01381833e-02, -1.07591732e-01,\n",
+       "       -6.97509237e-02, -1.81203419e-02,  5.07588313e-02,  7.70278313e-03,\n",
+       "       -3.91934584e-02,  9.29271190e-03, -1.05789516e-02,  5.07382832e-02,\n",
+       "        1.79365453e-02,  3.95959429e-02, -7.05412287e-02,  1.84834510e-02,\n",
+       "       -1.11977429e-02,  5.33773923e-02, -1.09056103e-02, -5.21385718e-04,\n",
+       "       -9.62118313e-02,  1.26625626e-02, -2.63540943e-03,  4.41537731e-02,\n",
+       "       -2.13807875e-02, -8.90874352e-02,  3.61685473e-02,  5.59569539e-03,\n",
+       "        5.50187110e-02,  2.30999628e-02, -8.18250372e-02, -9.67539810e-02,\n",
+       "        1.39515574e-03, -1.30428540e-02, -1.67898715e-02,  4.19755079e-02,\n",
+       "       -1.35061821e-01,  1.03066289e-01, -1.07917651e-02,  3.01890624e-03,\n",
+       "       -5.92328448e-02,  4.75648831e-02,  7.45972389e-02, -9.05823814e-03,\n",
+       "        1.82994498e-02,  1.16500409e-02,  7.42939271e-03, -4.46931791e-02,\n",
+       "        7.42094159e-02, -5.46884169e-02, -7.03193685e-02, -9.31773872e-03,\n",
+       "       -1.22923814e-01,  5.92522857e-02, -4.92985815e-03,  3.93452349e-02,\n",
+       "        8.33028820e-02,  6.81241415e-02, -7.86093796e-02,  2.12162651e-02,\n",
+       "        1.41766710e-01,  6.20479409e-02, -1.16216403e-02,  4.20055119e-02,\n",
+       "        9.74765075e-02, -7.44201397e-02, -2.96288767e-02,  7.02127622e-02,\n",
+       "       -4.76458459e-02,  6.80460547e-02, -6.91976046e-03, -8.56330230e-03,\n",
+       "       -1.01883747e-01, -5.74692367e-02, -5.49768553e-02,  3.37755873e-02,\n",
+       "       -1.31338067e-02, -1.86830728e-02,  1.30724431e-03,  4.37613545e-02,\n",
+       "       -1.80811246e-01, -1.62683251e-02, -3.85157321e-02,  4.35421743e-02,\n",
+       "        7.08648155e-02,  6.94852982e-03, -8.95057864e-02,  3.83461144e-02,\n",
+       "       -1.50225658e-01, -4.33895281e-02,  2.95122364e-02, -8.92602069e-03,\n",
+       "        1.41639198e-02, -5.44959091e-02, -6.25654612e-02, -1.61190105e-02,\n",
+       "       -4.08037712e-02,  3.92387535e-02, -1.61472882e-01, -2.07773657e-02])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ff.vectorize(\"my landlord kicked me out\", normalize=1)"
+    "ff.vectorize(\"my landlord kicked me out\", tools_token=tools_token)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "eb52b221",
    "metadata": {},
    "outputs": [
@@ -298,7 +307,7 @@
        "{'status': 401, 'message': 'Unauthorized token'}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,30 +318,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
+   "id": "de02250d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('Mistakes were made.', [(9, 18)])]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ff.get_passive_sentences(\"Mistakes were made. I am happy.\", tools_token=tools_token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "36f0c2f8",
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Detecting Sentences...\n",
-      "Starting to find passives...\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "{'title': '(Untitled)',\n",
+       "{'title': 'foc78.pmd',\n",
+       " 'suggested title': '',\n",
+       " 'description': '',\n",
        " 'category': None,\n",
        " 'pages': 1,\n",
-       " 'reading grade level': 6.0,\n",
-       " 'time to answer': (62.0, 68.0),\n",
-       " 'list': {'status': 401, 'message': 'Unauthorized token'},\n",
-       " 'avg fields per page': 18.0,\n",
+       " 'reading grade level': 9.0,\n",
+       " 'time to answer': (27.0, 5.6),\n",
+       " 'list': [],\n",
+       " 'avg fields per page': 17.0,\n",
        " 'fields': ['moving_party__1',\n",
        "  'moving_party__2',\n",
        "  'moving_party__3',\n",
@@ -345,30 +369,28 @@
        "  'county',\n",
        "  '*users1_address_line_one',\n",
        "  'telno',\n",
-       "  'name_address_telephone__1',\n",
-       "  'name_address_telephone__2',\n",
-       "  'third_name_address_telephone',\n",
+       "  'plaintiffs_address_telephone',\n",
+       "  'defendants_address_telephone',\n",
+       "  'third_partys_address_telephone',\n",
        "  'dated',\n",
-       "  'reasons',\n",
-       "  'form_instructions'],\n",
-       " 'fields_conf': [0.53,\n",
-       "  0.56,\n",
-       "  0.55,\n",
-       "  1.0,\n",
-       "  0.62,\n",
-       "  1.0,\n",
-       "  0.64,\n",
-       "  0.68,\n",
-       "  0.58,\n",
-       "  0.64,\n",
-       "  1.0,\n",
-       "  0.97,\n",
-       "  0.52,\n",
-       "  0.55,\n",
-       "  0.48,\n",
-       "  0.55,\n",
-       "  0.53,\n",
-       "  0.61],\n",
+       "  'reasons'],\n",
+       " 'fields_conf': [0.5,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.01,\n",
+       "  0.5,\n",
+       "  0.01,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.01,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.5,\n",
+       "  0.5],\n",
        " 'fields_old': ['moving party',\n",
        "  'moving party_2',\n",
        "  'moving party_3',\n",
@@ -385,17 +407,65 @@
        "  'Defendants name address and telephone',\n",
        "  'Third partys name address and telephone',\n",
        "  'dated',\n",
-       "  'reasons',\n",
-       "  'Form Instructions'],\n",
-       " 'text': \"Approved, SCAO. STATE OF MICHIGAN. JUDICIAL CIRCUIT. COUNTY. Original Court. 1st copy Moving party. 2nd copy Objecting party. 3rd copy Friend of the court. 4th copy Proof of service. 5th copy Proof of service. A. CASE NO. OBJECTION TO PROPOSED ORDER. Court address. Court telephone no. Plaintiff's name, address, and telephone no. moving party. Defendant's name, address, and telephone no. moving party. v. Third party's name, address, and telephone no. moving party. I received a notice to enter a proposed order without a hearing dated. I object to the entry of the proposed order and request a hearing by the court. My objection is based on the following reason s. C. B. D. E. Date. Moving party's signature. Name type or print. CERTIFICATE OF MAILING. I certify that on this date I served a copy of this objection on the parties or their attorneys by first class mail addressed to their. last known addresses as defined in MCR 3.203. F. Date. Signature of objecting party. FOC 78 3 11 OBJECTION TO PROPOSED ORDER. MCR 2.602 B. \",\n",
-       " 'original_text': \"Approved, SCAO\\n\\nSTATE OF MICHIGAN\\n\\nJUDICIAL CIRCUIT\\nCOUNTY\\n\\nOriginal - Court\\n1st copy - Moving party\\n2nd copy - Objecting party\\n\\n3rd copy - Friend of the court\\n4th copy - Proof of service\\n5th copy - Proof of service\\n\\nA\\n\\nCASE NO.\\n\\nOBJECTION TO PROPOSED ORDER\\n\\nCourt  address\\n\\nCourt  telephone  no.\\n\\nPlaintiff's name, address, and telephone no.\\n\\nmoving party\\n\\nDefendant's name, address, and telephone no.\\n\\nmoving party\\n\\nv\\n\\nThird party's name, address, and telephone no.\\n\\nmoving party\\n\\nI received a notice to enter a proposed order without a hearing dated\\nI object to the entry of the proposed order and request a hearing by the court.  My objection is based on the following reason(s):\\n\\nC\\n\\nB\\n\\nD\\n\\nE\\n\\nDate\\n\\nMoving party's signature\\n\\nName (type or print)\\n\\nCERTIFICATE OF MAILING\\n\\nI certify that on this date I served a copy of this objection on the parties or their attorneys by first-class mail addressed to their\\nlast-known addresses as defined in MCR 3.203.\\n\\nF\\n\\nDate\\n\\nSignature of objecting party\\n\\nFOC 78   (3/11)   OBJECTION TO PROPOSED ORDER\\n\\nMCR 2.602(B)\\n\\n\\x0c\",\n",
-       " 'number of sentences': 33,\n",
+       "  'reasons'],\n",
+       " 'sensitive data types': {},\n",
+       " 'text': \"Approved, SCAO. STATE OF MICHIGAN. JUDICIAL CIRCUIT. COUNTY. Original Court. 1st copy Moving party. 2nd copy Objecting party. 3rd copy Friend of the court. 4th copy Proof of service. 5th copy Proof of service. A. CASE NO. OBJECTION TO PROPOSED ORDER. Court address. Court telephone no. Plaintiff's name, address, and telephone no. moving party. Defendant's name, address, and telephone no. moving party. v. Third party's name, address, and telephone no. moving party. I received a notice to enter a proposed order without a hearing dated. I object to the entry of the proposed order and request a hearing by the court. My objection is based on the following reason s. C. Moving party's signature. Name type or print. CERTIFICATE OF MAILING. Signature of objecting party. I certify that on this date I served a copy of this objection on the parties or their attorneys by first class mail addressed to their. last known addresses as defined in MCR 3.203. FOC 78 3 11 OBJECTION TO PROPOSED ORDER. MCR 2.602 B. B. D. E. Date. F. Date. \",\n",
+       " 'original_text': \"Approved, SCAO\\n\\nSTATE OF MICHIGAN\\n\\nJUDICIAL CIRCUIT\\nCOUNTY\\n\\nOriginal - Court\\n1st copy - Moving party\\n2nd copy - Objecting party\\n\\n3rd copy - Friend of the court\\n4th copy - Proof of service\\n5th copy - Proof of service\\n\\nA\\n\\nCASE NO.\\n\\nOBJECTION TO PROPOSED ORDER\\n\\nCourt  address\\n\\nCourt  telephone  no.\\n\\nPlaintiff's name, address, and telephone no.\\n\\nmoving party\\n\\nDefendant's name, address, and telephone no.\\n\\nmoving party\\n\\nv\\n\\nThird party's name, address, and telephone no.\\n\\nmoving party\\n\\nI received a notice to enter a proposed order without a hearing dated\\nI object to the entry of the proposed order and request a hearing by the court.  My objection is based on the following reason(s):\\n\\nC\\n\\nMoving party's signature\\n\\nName (type or print)\\n\\nCERTIFICATE OF MAILING\\n\\nSignature of objecting party\\n\\nI certify that on this date I served a copy of this objection on the parties or their attorneys by first-class mail addressed to their\\nlast-known addresses as defined in MCR 3.203.\\n\\nFOC 78   (3/11)   OBJECTION TO PROPOSED ORDER\\n\\nMCR 2.602(B)\\n\\nB\\n\\nD\\n\\nE\\n\\nDate\\n\\nF\\n\\nDate\\n\\n\\x0c\",\n",
+       " 'number of sentences': 8,\n",
+       " 'sentences per page': 8.0,\n",
        " 'number of passive voice sentences': 0,\n",
+       " 'passive sentences': [],\n",
        " 'number of all caps words': 23,\n",
-       " 'citations': []}"
+       " 'citations': [],\n",
+       " 'total fields': 17,\n",
+       " 'slotin percent': 0.5882352941176471,\n",
+       " 'gathered percent': 0.4117647058823529,\n",
+       " 'created percent': 0.0,\n",
+       " 'third party percent': 0.0,\n",
+       " 'passive voice percent': 0.0,\n",
+       " 'citations per field': 0.0,\n",
+       " 'citation count': 0,\n",
+       " 'all caps percent': 0.12994350282485875,\n",
+       " 'normalized characters per field': 8.570588235294121,\n",
+       " 'difficult words': ['received',\n",
+       "  'signature',\n",
+       "  'objecting',\n",
+       "  'dated',\n",
+       "  'judicial',\n",
+       "  \"defendant's\",\n",
+       "  \"plaintiff's\",\n",
+       "  'proposed',\n",
+       "  'request',\n",
+       "  'approved',\n",
+       "  'circuit',\n",
+       "  \"party's\",\n",
+       "  'object',\n",
+       "  'certify',\n",
+       "  'objection',\n",
+       "  'addresses',\n",
+       "  'attorneys',\n",
+       "  'entry',\n",
+       "  'michigan',\n",
+       "  'addressed',\n",
+       "  'parties',\n",
+       "  'certificate',\n",
+       "  'mailing',\n",
+       "  'defined',\n",
+       "  'original'],\n",
+       " 'difficult word count': 25,\n",
+       " 'difficult word percent': 0.14124293785310735,\n",
+       " 'calculation required': False,\n",
+       " 'plain language suggestions': [('moving party\\n\\nI received a notice to enter a proposed order without a hearing dated\\nI object to the entry of the proposed order and request a hearing by the court.',\n",
+       "   'moving party\\n\\nI received a notice to enter a proposed order without a hearing dated\\nI object to the entry of the proposed order and [ask, question, document asking for] a hearing by the court.',\n",
+       "   [(132, 168)]),\n",
+       "  (\"My objection is based on the following reason(s):\\n\\nC\\n\\nMoving party's signature\\n\\nName (type or print)\\n\\nCERTIFICATE OF MAILING\\n\\nSignature of objecting party\\n\\nI certify that on this date I served a copy of this objection on the parties or their attorneys by first-class mail addressed to their\\nlast-known addresses as defined in MCR 3.203.\",\n",
+       "   \"My objection is based on the [after, per, under] reason(s):\\n\\nC\\n\\nMoving party's signature\\n\\nName (type or print)\\n\\nCERTIFICATE OF MAILING\\n\\nSignature of objecting party\\n\\nI certify that on this date I served a copy of this objection on the parties or their attorneys by first-class mail addressed to their\\nlast-known addresses as defined in MCR 3.203.\",\n",
+       "   [(29, 48)])],\n",
+       " 'neutral gender suggestions': [],\n",
+       " 'pdf_is_tagged': False}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -407,8 +477,9 @@
     "    jur=\"UT\",\n",
     "    cat=None,\n",
     "    normalize=1,\n",
-    "    use_spot=1,\n",
+    "    #use_spot=1,\n",
     "    rewrite=0,\n",
+    "    tools_token=tools_token\n",
     ")\n",
     "stats"
    ]
@@ -467,13 +538,13 @@
     "]\n",
     "\n",
     "\n",
-    "ff.cluster_screens(fields, damping=0.7)"
+    "ff.cluster_screens(fields, damping=0.7, tools_token=tools_token)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "691429b5",
+   "id": "ca67d272",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/setup.py
+++ b/setup.py
@@ -6,17 +6,17 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 # We can't simply include this as an install_requires, because pypi won't allow
 # projects with github dependencies to be hosted there.
-class InstallSpacyModelCommand(install):
-    def run(self):
-        install.run(self)
-        import spacy
-        print("Downloading word2vec model en_core_web_sm")
-        spacy.cli.download('en_core_web_sm')
+#class InstallSpacyModelCommand(install):
+#    def run(self):
+#        install.run(self)
+#        import spacy
+#        print("Downloading word2vec model en_core_web_sm")
+#        spacy.cli.download('en_core_web_sm')
 
 
 setuptools.setup(
     name='formfyxer',
-    version='0.3.0a2',
+    version='0.3.0a3',
     author='Suffolk LIT Lab',
     author_email='litlab@suffolk.edu',
     description='A tool for learning about and pre-processing pdf forms.',
@@ -35,8 +35,8 @@ setuptools.setup(
         'typer>=0.4.1,<0.5.0', # typer pre 0.4.1 was broken by click 8.1.0: https://github.com/explosion/spaCy/issues/10564
         'openai', 'python-docx', 'tiktoken', 'transformers' 
     ],
-    cmdclass={
-      'install': InstallSpacyModelCommand,
-    },
+    #cmdclass={
+    #  'install': InstallSpacyModelCommand,
+    #},
     include_package_data = True
 )


### PR DESCRIPTION
I removed all uses of SpaCy, hopefully, stepping around the conflict that presented in the Weaver with updates to other packages. I was only able to do this, however, by making use of the tools.suffolklitlab.org micro-services: `vectorize` and `passive`. You can see the testing results in `dev-testing/test package.ipynb` Unfortunately, this means that there are now a number of features that require a tools_token to work. I have not updated the documentation to make this clear, but I will open an issue. Also, I'm not sure if we want to push this change to PiPy or have the Weaver install from this branch as a hot fix. Obviously, where Weaver calls these functions no using tools, we'll need to pass a token.