### PR TITLE
Allow working without .env; pull creds from docassemble config

### DIFF
--- a/formfyxer/docassemble_support.py
+++ b/formfyxer/docassemble_support.py
@@ -9,7 +9,7 @@ import os
 
 # Try to import docassemble config function at module level for performance
 try:
-    from docassemble.base.util import get_config  # type: ignore[import-untyped]
+    from docassemble.base.util import get_config  # type: ignore[import-not-found, import-untyped]
     _DOCASSEMBLE_AVAILABLE = True
     _da_get_config = get_config
 except ImportError:

--- a/formfyxer/docassemble_support.py
+++ b/formfyxer/docassemble_support.py
@@ -1,0 +1,88 @@
+"""Support for docassemble configuration integration.
+
+This module provides centralized support for accessing docassemble configuration
+values, with graceful fallback when docassemble is not available.
+"""
+
+from typing import Optional, Dict, Any
+import os
+
+# Try to import docassemble config function at module level for performance
+try:
+    from docassemble.base.util import get_config as _da_get_config
+
+    _DOCASSEMBLE_AVAILABLE = True
+except ImportError:
+    _da_get_config = None
+    _DOCASSEMBLE_AVAILABLE = False
+
+
+def get_openai_api_key(explicit_key: Optional[str] = None) -> Optional[str]:
+    """Get OpenAI API key with fallback to docassemble config if available.
+
+    This function implements the following priority order:
+    1. Explicit API key parameter (highest priority)
+    2. Docassemble get_config("openai api key")
+    3. Docassemble get_config("open ai", {}).get("key")
+    4. OPENAI_API_KEY environment variable (lowest priority)
+
+    Args:
+        explicit_key: Explicitly provided API key (takes highest precedence)
+
+    Returns:
+        The API key to use, or None if none found
+    """
+    if explicit_key:
+        return explicit_key
+
+    # Try docassemble config if available (cached import at module level)
+    if _DOCASSEMBLE_AVAILABLE and _da_get_config:
+        # Try the direct key first
+        da_key = _da_get_config("openai api key")
+        if da_key:
+            return da_key
+        # Try the nested config
+        openai_config = _da_get_config("open ai", {})
+        if isinstance(openai_config, dict) and "key" in openai_config:
+            return openai_config["key"]
+
+    # Fall back to environment variable
+    return os.getenv("OPENAI_API_KEY")
+
+
+def get_openai_api_key_from_sources(
+    explicit_key: Optional[str] = None, creds: Optional[Dict[str, Any]] = None
+) -> Optional[str]:
+    """Get OpenAI API key with fallback through multiple sources.
+
+    This function implements the following priority order:
+    1. Explicit API key parameter (highest priority)
+    2. Credentials dict "key" field
+    3. Docassemble get_config("openai api key")
+    4. Docassemble get_config("open ai", {}).get("key")
+    5. OPENAI_API_KEY environment variable (lowest priority)
+
+    Args:
+        explicit_key: Explicitly provided API key (takes highest precedence)
+        creds: Credentials dict that may contain a "key" field
+
+    Returns:
+        The API key to use, or None if none found
+    """
+    if explicit_key:
+        return explicit_key
+
+    if creds and "key" in creds:
+        return creds["key"]
+
+    # Delegate to the main function for docassemble and env var fallback
+    return get_openai_api_key()
+
+
+def is_docassemble_available() -> bool:
+    """Check if docassemble is available in the current environment.
+
+    Returns:
+        True if docassemble.base.util can be imported, False otherwise
+    """
+    return _DOCASSEMBLE_AVAILABLE

--- a/formfyxer/docassemble_support.py
+++ b/formfyxer/docassemble_support.py
@@ -9,12 +9,13 @@ import os
 
 # Try to import docassemble config function at module level for performance
 try:
-    from docassemble.base.util import get_config as _da_get_config
-
+    from docassemble.base.util import get_config  # type: ignore[import-untyped]
     _DOCASSEMBLE_AVAILABLE = True
+    _da_get_config = get_config
 except ImportError:
-    _da_get_config = None
+    get_config = None
     _DOCASSEMBLE_AVAILABLE = False
+    _da_get_config = None
 
 
 def get_openai_api_key(explicit_key: Optional[str] = None) -> Optional[str]:

--- a/formfyxer/integration_tests/interactive_test_api_key_resolution.py
+++ b/formfyxer/integration_tests/interactive_test_api_key_resolution.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Test script to verify API key resolution works correctly."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add the formfyxer package to the path (go up two levels from integration_tests to reach the root)
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from formfyxer.docassemble_support import (
+    get_openai_api_key,
+    get_openai_api_key_from_sources,
+    is_docassemble_available,
+)
+
+
+def test_api_key_resolution():
+    """Test the API key resolution functions."""
+    print("🔬 Testing API key resolution functions")
+    print("=" * 50)
+
+    # Test 1: Environment variable (should work)
+    print("\n1. Testing environment variable resolution:")
+    env_key = get_openai_api_key()
+    if env_key:
+        print(f"✅ Found API key from environment: {env_key[:10]}...")
+    else:
+        print("❌ No API key found in environment")
+
+    # Test 2: Explicit key takes precedence
+    print("\n2. Testing explicit key takes precedence:")
+    explicit_key = "test-explicit-key"
+    result = get_openai_api_key(explicit_key)
+    if result == explicit_key:
+        print("✅ Explicit key correctly takes precedence")
+    else:
+        print(f"❌ Expected explicit key, got: {result}")
+
+    # Test 3: Test sources function
+    print("\n3. Testing get_openai_api_key_from_sources:")
+    creds = {"key": "test-creds-key", "org": "test-org"}
+
+    # Explicit key should take precedence over creds
+    result = get_openai_api_key_from_sources("explicit-key", creds)
+    if result == "explicit-key":
+        print("✅ Explicit key takes precedence over creds")
+    else:
+        print(f"❌ Expected explicit key, got: {result}")
+
+    # Creds key should be used if no explicit key
+    result = get_openai_api_key_from_sources(None, creds)
+    if result == "test-creds-key":
+        print("✅ Creds key used when no explicit key")
+    else:
+        print(f"❌ Expected creds key, got: {result}")
+
+    # Test 4: Test docassemble availability and fallback
+    print("\n4. Testing docassemble config detection:")
+    docassemble_available = is_docassemble_available()
+    print(f"💡 Docassemble available: {docassemble_available}")
+
+    result = get_openai_api_key()  # Should fall back to environment
+    if result:
+        print(f"✅ API key resolution works: {result[:10]}...")
+        if docassemble_available:
+            print("   (May include docassemble config)")
+        else:
+            print("   (Environment fallback)")
+    else:
+        print("❌ No API key found from any source")
+
+    print("\n" + "=" * 50)
+    print("🏁 API key resolution test completed!")
+
+
+def test_integration():
+    """Test that the integration works end-to-end."""
+    print("\n🔬 Testing end-to-end integration")
+    print("=" * 50)
+    print("⚠️  Note: This may take time due to NLTK/docassemble initialization")
+
+    try:
+        print("   Importing passive voice detection module...")
+        from formfyxer.passive_voice_detection import detect_passive_voice_segments
+
+        # Load API key from .env file if available
+        env_file = Path(__file__).parent.parent.parent / ".env"
+        api_key = None
+        if env_file.exists():
+            with open(env_file) as f:
+                for line in f:
+                    if line.startswith("OPENAI_API_KEY="):
+                        api_key = line.split("=", 1)[1].strip()
+                        os.environ["OPENAI_API_KEY"] = api_key
+                        break
+
+        if not api_key:
+            api_key = os.getenv("OPENAI_API_KEY")
+
+        # Test with explicit API key
+        if api_key and api_key.startswith("sk-"):
+            print("\n1. Testing passive voice detection with explicit API key:")
+            result = detect_passive_voice_segments(
+                "The ball was thrown by John.", api_key=api_key
+            )
+            print(f"✅ Explicit API key parameter works: {len(result)} results")
+
+            print("\n2. Testing passive voice detection with default resolution:")
+            result = detect_passive_voice_segments("The ball was thrown by John.")
+            print(f"✅ Default API key resolution works: {len(result)} results")
+        else:
+            print("⚠️  No valid OPENAI_API_KEY found, skipping live tests")
+            print("   (API key should start with 'sk-' to be valid)")
+
+    except Exception as e:
+        print(f"❌ Integration test failed: {e}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    test_api_key_resolution()
+
+    # Only run integration test if not skipped
+    if "--skip-integration" not in sys.argv:
+        test_integration()
+    else:
+        print("\n⚠️  Integration test skipped (use without --skip-integration to run)")
+        print(
+            "   Integration test imports full modules which may be slow due to NLTK/docassemble"
+        )

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -799,7 +799,7 @@ def text_complete(
         api_key (Optional[str], optional): Explicit API key to use. Defaults to None.
     """
     # Resolve the API key using our helper function
-    resolved_key = get_openai_api_key_from_sources(api_key, creds)
+    resolved_key = get_openai_api_key_from_sources(api_key, dict(creds) if creds else None)
 
     if resolved_key:
         openai_client = OpenAI(

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -1146,7 +1146,7 @@ def parse_form(
             any creds or environment variables
         rewrite: whether to rewrite the PDF in place with the new field names
         debug: whether to print debug information
-    
+
     Returns: a dictionary of information about the form
     """
     unlock_pdf_in_place(in_file)
@@ -1166,10 +1166,9 @@ def parse_form(
         ff = None
     # Resolve API key once at the top for consistency
     resolved_api_key = get_openai_api_key_from_sources(
-        openai_api_key, 
-        dict(openai_creds) if openai_creds else None
+        openai_api_key, dict(openai_creds) if openai_creds else None
     )
-    
+
     field_names = [field.name for field in ff] if ff else []
     f_per_page = len(field_names) / pages_count
     # some PDFs (698c6784e6b9b9518e5390fd9ec31050) have vertical text, but it's not detected.
@@ -1266,9 +1265,7 @@ def parse_form(
     sentences = [s for s in tokenized_sentences if len(s.split(" ")) > 2]
 
     try:
-        passive_sentences = get_passive_sentences(
-            sentences, api_key=resolved_api_key
-        )
+        passive_sentences = get_passive_sentences(sentences, api_key=resolved_api_key)
         passive_sentences_count = len(passive_sentences)
     except ValueError:
         passive_sentences_count = 0

--- a/formfyxer/lit_explorer.py
+++ b/formfyxer/lit_explorer.py
@@ -65,6 +65,7 @@ from openai import OpenAI
 from dotenv import load_dotenv
 
 from .passive_voice_detection import detect_passive_voice_segments, split_sentences
+from .docassemble_support import get_openai_api_key_from_sources
 
 from transformers import GPT2TokenizerFast
 
@@ -786,6 +787,7 @@ def text_complete(
     max_tokens: int = 500,
     creds: Optional[OpenAiCreds] = None,
     temperature: float = 0,
+    api_key: Optional[str] = None,
 ) -> str:
     """Run a prompt via openAI's API and return the result.
 
@@ -794,8 +796,16 @@ def text_complete(
         max_tokens (int, optional): The number of tokens to generate. Defaults to 500.
         creds (Optional[OpenAiCreds], optional): The credentials to use. Defaults to None.
         temperature (float, optional): The temperature to use. Defaults to 0.
+        api_key (Optional[str], optional): Explicit API key to use. Defaults to None.
     """
-    if creds:
+    # Resolve the API key using our helper function
+    resolved_key = get_openai_api_key_from_sources(api_key, creds)
+
+    if resolved_key:
+        openai_client = OpenAI(
+            api_key=resolved_key, organization=creds.get("org") if creds else None
+        )
+    elif creds:
         openai_client = OpenAI(api_key=creds["key"], organization=creds["org"])
     else:
         if client:
@@ -821,7 +831,11 @@ def text_complete(
 
 
 def complete_with_command(
-    text, command, tokens, creds: Optional[OpenAiCreds] = None
+    text,
+    command,
+    tokens,
+    creds: Optional[OpenAiCreds] = None,
+    api_key: Optional[str] = None,
 ) -> str:
     """Combines some text with a command to send to open ai."""
     # OpenAI's max number of tokens length is 4097, so we trim the input text to 4080 - command - tokens length.
@@ -833,7 +847,9 @@ def complete_with_command(
         text = tokenizer.decode(
             tokenizer(text, truncation=True, max_length=max_length)["input_ids"]
         )
-    return text_complete(text + "\n\n" + command, max_tokens=tokens, creds=creds)
+    return text_complete(
+        text + "\n\n" + command, max_tokens=tokens, creds=creds, api_key=api_key
+    )
 
 
 def plain_lang(text, creds: Optional[OpenAiCreds] = None) -> str:
@@ -842,14 +858,18 @@ def plain_lang(text, creds: Optional[OpenAiCreds] = None) -> str:
     return complete_with_command(text, command, tokens, creds=creds)
 
 
-def guess_form_name(text, creds: Optional[OpenAiCreds] = None) -> str:
+def guess_form_name(
+    text, creds: Optional[OpenAiCreds] = None, api_key: Optional[str] = None
+) -> str:
     command = 'If the above is a court form, write the form\'s name, otherwise respond with the word "abortthisnow.".'
-    return complete_with_command(text, command, 20, creds=creds)
+    return complete_with_command(text, command, 20, creds=creds, api_key=api_key)
 
 
-def describe_form(text, creds: Optional[OpenAiCreds] = None) -> str:
+def describe_form(
+    text, creds: Optional[OpenAiCreds] = None, api_key: Optional[str] = None
+) -> str:
     command = 'If the above is a court form, write a brief description of its purpose at a sixth grade reading level, otherwise respond with the word "abortthisnow.".'
-    return complete_with_command(text, command, 250, creds=creds)
+    return complete_with_command(text, command, 250, creds=creds, api_key=api_key)
 
 
 def needs_calculations(text: Union[str]) -> bool:
@@ -876,7 +896,10 @@ def needs_calculations(text: Union[str]) -> bool:
 
 
 def get_passive_sentences(
-    text: Union[List, str], tools_token: Optional[str] = None, model: str = "gpt-5-nano"
+    text: Union[List, str],
+    tools_token: Optional[str] = None,
+    model: str = "gpt-5-nano",
+    api_key: Optional[str] = None,
 ) -> List[Tuple[str, List[Tuple[int, int]]]]:
     """Return passive voice fragments for each sentence in ``text``.
 
@@ -889,6 +912,8 @@ def get_passive_sentences(
         tools_token (Optional[str], optional): Deprecated. Previously used for authentication with
             tools.suffolklitlab.org. Defaults to None.
         model (str, optional): The OpenAI model to use for detection. Defaults to "gpt-5-nano".
+        api_key (Optional[str], optional): OpenAI API key to use. If None, will try docassemble
+            config (if available) then environment variables. Defaults to None.
     Returns:
         List[Tuple[str, List[Tuple[int, int]]]]: A list of tuples, each containing the original text
             and a list of tuples representing the start and end positions of detected passive voice fragments.
@@ -907,6 +932,7 @@ def get_passive_sentences(
         text,
         openai_client=client if client else None,
         model=model,
+        api_key=api_key,
     )
 
     for item in passive_voice_results:
@@ -1095,6 +1121,7 @@ def parse_form(
     spot_token: Optional[str] = None,
     tools_token: Optional[str] = None,
     openai_creds: Optional[OpenAiCreds] = None,
+    openai_api_key: Optional[str] = None,
     rewrite: bool = False,
     debug: bool = False,
 ):
@@ -1102,6 +1129,7 @@ def parse_form(
     Read in a pdf, pull out basic stats, attempt to normalize its form fields, and re-write the
     in_file with the new fields (if `rewrite=1`). If you pass a spot token, we will guess the
     NSMI code. If you pass openai creds, we will give suggestions for the title and description.
+    If you pass openai_api_key, it will be used for passive voice detection (overrides creds and env vars).
     """
     unlock_pdf_in_place(in_file)
     the_pdf = pikepdf.open(in_file)
@@ -1126,7 +1154,15 @@ def parse_form(
     # ocrmypdf.
     original_text = extract_text(in_file, laparams=LAParams(detect_vertical=True))
     text = cleanup_text(original_text)
-    description = describe_form(text, creds=openai_creds) if openai_creds else ""
+    # Use either the explicit API key or from creds for description
+    api_key_for_description = openai_api_key or (
+        openai_creds.get("key") if openai_creds else None
+    )
+    description = (
+        describe_form(text, creds=openai_creds, api_key=api_key_for_description)
+        if (openai_creds or openai_api_key)
+        else ""
+    )
     try:
         readability = textstat.text_standard(text, float_output=True) if text else -1
     except:
@@ -1158,7 +1194,15 @@ def parse_form(
             except:
                 readability = -1
 
-    new_title = guess_form_name(text, creds=openai_creds) if openai_creds else ""
+    # Use either the explicit API key or from creds for title guessing
+    api_key_for_title = openai_api_key or (
+        openai_creds.get("key") if openai_creds else None
+    )
+    new_title = (
+        guess_form_name(text, creds=openai_creds, api_key=api_key_for_title)
+        if (openai_creds or openai_api_key)
+        else ""
+    )
     if not title:
         if hasattr(the_pdf.docinfo, "Title"):
             title = str(the_pdf.docinfo.Title)
@@ -1206,7 +1250,14 @@ def parse_form(
     sentences = [s for s in tokenized_sentences if len(s.split(" ")) > 2]
 
     try:
-        passive_sentences = get_passive_sentences(sentences, tools_token=tools_token)
+        # Determine which API key to use (explicit parameter takes precedence)
+        api_key_to_use = openai_api_key
+        if not api_key_to_use and openai_creds:
+            api_key_to_use = openai_creds.get("key")
+
+        passive_sentences = get_passive_sentences(
+            sentences, tools_token=tools_token, api_key=api_key_to_use
+        )
         passive_sentences_count = len(passive_sentences)
     except ValueError:
         passive_sentences_count = 0


### PR DESCRIPTION
Fix #149 

This normalizes the new passive detection function so that an API key can be provided as a parameter, which always takes precedence when so provided. Additionally, it adds in a shim to allow directly pulling API key from the Docassemble global configuration if it isn't explicitly provided as a parameter.